### PR TITLE
BEC-1-abstract-grid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,16 @@ project(BECpp)
 
 set(CMAKE_CXX_STANDARD 20)
 
-set(SOURCES src/main.cpp src/grid.cpp src/wavefunction.cpp src/data.cpp)
-set(INCLUDES include/constants.h include/grid.h include/wavefunction.h include/data.h include/evolution.h include/phase.h)
+set(SOURCES src/grid.cpp)
+set(INCLUDES include/constants.h include/grid.h)
 
 find_package(OpenMP REQUIRED)
 
-add_executable(${PROJECT_NAME} ${SOURCES} ${INCLUDES})
+add_library(${PROJECT_NAME} STATIC ${SOURCES} ${INCLUDES})
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/include/
-        ${PROJECT_SOURCE_DIR}/lib/fftw ${PROJECT_SOURCE_DIR}/lib/HighFive/include
-        ${PROJECT_SOURCE_DIR}/lib/HDF5/1.12.1/include)
-target_link_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/lib/fftw
-        ${PROJECT_SOURCE_DIR}/lib/HDF5/1.12.1/lib)
-target_link_libraries(${PROJECT_NAME} libfftw3-3 hdf5 OpenMP::OpenMP_CXX)
+target_include_directories(${PROJECT_NAME} PRIVATE
+        ${PROJECT_SOURCE_DIR}/include/)
+target_link_libraries(${PROJECT_NAME} OpenMP::OpenMP_CXX)
+
+enable_testing()
+add_subdirectory(test)

--- a/include/evolution.h
+++ b/include/evolution.h
@@ -18,11 +18,11 @@ void apply_TF_density(Wavefunction2D &psi, const Parameters &params)
     double g = params.c0 + 4 * params.c2;
     double r_tf = std::pow(8 * g / PI, 0.25);
 
-    for (int i = 0; i < psi.grid.nx; ++i)
+    for (int i = 0; i < psi.grid.m_xPoints; ++i)
     {
-        for (int j = 0; j < psi.grid.ny; ++j)
+        for (int j = 0; j < psi.grid.m_yPoints; ++j)
         {
-            double r2 = psi.grid.X[i][j] * psi.grid.X[i][j] + psi.grid.Y[i][j] * psi.grid.Y[i][j];
+            double r2 = psi.grid.m_xMesh[i][j] * psi.grid.m_xMesh[i][j] + psi.grid.m_yMesh[i][j] * psi.grid.m_yMesh[i][j];
 
             if (r2 < r_tf)
             {
@@ -33,9 +33,9 @@ void apply_TF_density(Wavefunction2D &psi, const Parameters &params)
                 tf_density = 0.;
             }
 
-            psi.plus[j + i * psi.grid.ny] *= tf_density;
-            psi.zero[j + i * psi.grid.ny] *= tf_density;
-            psi.minus[j + i * psi.grid.ny] *= tf_density;
+            psi.plus[j + i * psi.grid.m_yPoints] *= tf_density;
+            psi.zero[j + i * psi.grid.m_yPoints] *= tf_density;
+            psi.minus[j + i * psi.grid.m_yPoints] *= tf_density;
         }
     }
 
@@ -45,13 +45,13 @@ void apply_TF_density(Wavefunction2D &psi, const Parameters &params)
 void fourier_step(Wavefunction2D &psi, const Parameters &params)
 {
 #pragma omp parallel for collapse(2) shared(psi, params, I) default(none)
-    for (int i = 0; i < psi.grid.nx; ++i)
+    for (int i = 0; i < psi.grid.m_xPoints; ++i)
     {
-        for (int j = 0; j < psi.grid.ny; ++j)
+        for (int j = 0; j < psi.grid.m_yPoints; ++j)
         {
-            psi.plus_k[j + i * psi.grid.ny] *= exp(-0.25 * I * params.dt * (psi.grid.K[i][j] + 2 * params.q));
-            psi.zero_k[j + i * psi.grid.ny] *= exp(-0.25 * I * params.dt * psi.grid.K[i][j]);
-            psi.minus_k[j + i * psi.grid.ny] *= exp(-0.25 * I * params.dt * (psi.grid.K[i][j] + 2 * params.q));
+            psi.plus_k[j + i * psi.grid.m_yPoints] *= exp(-0.25 * I * params.dt * (psi.grid.m_wavenumber[i][j] + 2 * params.q));
+            psi.zero_k[j + i * psi.grid.m_yPoints] *= exp(-0.25 * I * params.dt * psi.grid.m_wavenumber[i][j]);
+            psi.minus_k[j + i * psi.grid.m_yPoints] *= exp(-0.25 * I * params.dt * (psi.grid.m_wavenumber[i][j] + 2 * params.q));
         }
     }
 }
@@ -59,11 +59,11 @@ void fourier_step(Wavefunction2D &psi, const Parameters &params)
 void fourier_step(Wavefunction1D &psi, const Parameters &params)
 {
 #pragma omp parallel for shared(psi, params, I) default(none)
-    for (int i = 0; i < psi.grid.nx; ++i)
+    for (int i = 0; i < psi.grid.m_xPoints; ++i)
     {
-        psi.plus_k[i] *= exp(-0.25 * I * params.dt * (psi.grid.K[i] + 2 * params.q));
-        psi.zero_k[i] *= exp(-0.25 * I * params.dt * psi.grid.K[i]);
-        psi.minus_k[i] *= exp(-0.25 * I * params.dt * (psi.grid.K[i] + 2 * params.q));
+        psi.plus_k[i] *= exp(-0.25 * I * params.dt * (psi.grid.m_wavenumber[i] + 2 * params.q));
+        psi.zero_k[i] *= exp(-0.25 * I * params.dt * psi.grid.m_wavenumber[i]);
+        psi.minus_k[i] *= exp(-0.25 * I * params.dt * (psi.grid.m_wavenumber[i] + 2 * params.q));
 
     }
 }
@@ -71,29 +71,29 @@ void fourier_step(Wavefunction1D &psi, const Parameters &params)
 void fourier_step_KZ(Wavefunction1D &psi, const Parameters &params, int tau_q)
 {
 #pragma omp parallel for shared(psi, params, I, tau_q) default(none)
-    for (int i = 0; i < psi.grid.nx; ++i)
+    for (int i = 0; i < psi.grid.m_xPoints; ++i)
     {
         psi.plus_k[i] *= exp(-0.25 * I * params.dt *
-                             (psi.grid.K[i] + 2 * abs(params.c2) * (params.q - params.dt.real() / (2 * tau_q))));
-        psi.zero_k[i] *= exp(-0.25 * I * params.dt * psi.grid.K[i]);
+                             (psi.grid.m_wavenumber[i] + 2 * abs(params.c2) * (params.q - params.dt.real() / (2 * tau_q))));
+        psi.zero_k[i] *= exp(-0.25 * I * params.dt * psi.grid.m_wavenumber[i]);
         psi.minus_k[i] *= exp(-0.25 * I * params.dt *
-                              (psi.grid.K[i] + 2 * abs(params.c2) * (params.q - params.dt.real() / (2 * tau_q))));
+                              (psi.grid.m_wavenumber[i] + 2 * abs(params.c2) * (params.q - params.dt.real() / (2 * tau_q))));
     }
 }
 
 void interaction_step(Wavefunction2D &psi, const Parameters &params, const doubleArray_t &V)
 {
 #pragma omp parallel for collapse(2) shared(psi, params, I, V) default(none)
-    for (int i = 0; i < psi.grid.nx; ++i)
+    for (int i = 0; i < psi.grid.m_xPoints; ++i)
     {
-        for (int j = 0; j < psi.grid.ny; ++j)
+        for (int j = 0; j < psi.grid.m_yPoints; ++j)
         {
             // Calculate spin vector elements
             std::complex<double> f_perp =
-                    sqrt(2.) * (std::conj(psi.plus[j + i * psi.grid.ny]) * psi.zero[j + i * psi.grid.ny]
-                                + std::conj(psi.zero[j + i * psi.grid.ny]) * psi.minus[j + i * psi.grid.ny]);
-            std::complex<double> f_z = std::pow(abs(psi.plus[j + i * psi.grid.ny]), 2) -
-                                       std::pow(abs(psi.minus[j + i * psi.grid.ny]), 2);
+                    sqrt(2.) * (std::conj(psi.plus[j + i * psi.grid.m_yPoints]) * psi.zero[j + i * psi.grid.m_yPoints]
+                                + std::conj(psi.zero[j + i * psi.grid.m_yPoints]) * psi.minus[j + i * psi.grid.m_yPoints]);
+            std::complex<double> f_z = std::pow(abs(psi.plus[j + i * psi.grid.m_yPoints]), 2) -
+                                       std::pow(abs(psi.minus[j + i * psi.grid.m_yPoints]), 2);
             double F = sqrt(std::pow(abs(f_z), 2) + std::pow(abs(f_perp), 2));
 
             // Calculate trigonometric expressions
@@ -105,32 +105,32 @@ void interaction_step(Wavefunction2D &psi, const Parameters &params, const doubl
             }
 
             // Calculate density
-            double n = std::pow(abs(psi.plus[j + i * psi.grid.ny]), 2) +
-                       std::pow(abs(psi.zero[j + i * psi.grid.ny]), 2) +
-                       std::pow(abs(psi.minus[j + i * psi.grid.ny]), 2);
+            double n = std::pow(abs(psi.plus[j + i * psi.grid.m_yPoints]), 2) +
+                       std::pow(abs(psi.zero[j + i * psi.grid.m_yPoints]), 2) +
+                       std::pow(abs(psi.minus[j + i * psi.grid.m_yPoints]), 2);
 
             // Solve interaction part of flow
-            std::complex<double> new_psi_plus = (C * psi.plus[j + i * psi.grid.ny] -
-                                                 S * (f_z * psi.plus[j + i * psi.grid.ny]
-                                                      + std::conj(f_perp) / sqrt(2.) * psi.zero[j + i * psi.grid.ny]))
+            std::complex<double> new_psi_plus = (C * psi.plus[j + i * psi.grid.m_yPoints] -
+                                                 S * (f_z * psi.plus[j + i * psi.grid.m_yPoints]
+                                                      + std::conj(f_perp) / sqrt(2.) * psi.zero[j + i * psi.grid.m_yPoints]))
                                                 * exp(-I * params.dt * (V[i][j] - params.p + params.c0 * n));
 
             // Solve interaction part of flow
-            std::complex<double> new_psi_zero = (C * psi.zero[j + i * psi.grid.ny] -
-                                                 S / sqrt(2.) * (f_perp * psi.plus[j + i * psi.grid.ny]
-                                                                 + std::conj(f_perp) * psi.minus[j + i * psi.grid.ny]))
+            std::complex<double> new_psi_zero = (C * psi.zero[j + i * psi.grid.m_yPoints] -
+                                                 S / sqrt(2.) * (f_perp * psi.plus[j + i * psi.grid.m_yPoints]
+                                                                 + std::conj(f_perp) * psi.minus[j + i * psi.grid.m_yPoints]))
                                                 * exp(-I * params.dt * (V[i][j] + params.c0 * n));
 
             // Solve interaction part of flow
-            std::complex<double> new_psi_minus = (C * psi.minus[j + i * psi.grid.ny] -
-                                                  S * (f_perp / sqrt(2.) * psi.zero[j + i * psi.grid.ny]
-                                                       - f_z * psi.minus[j + i * psi.grid.ny]))
+            std::complex<double> new_psi_minus = (C * psi.minus[j + i * psi.grid.m_yPoints] -
+                                                  S * (f_perp / sqrt(2.) * psi.zero[j + i * psi.grid.m_yPoints]
+                                                       - f_z * psi.minus[j + i * psi.grid.m_yPoints]))
                                                  * exp(-I * params.dt * (V[i][j] + params.p + params.c0 * n));
 
             // Update wavefunction
-            psi.plus[j + i * psi.grid.ny] = new_psi_plus;
-            psi.zero[j + i * psi.grid.ny] = new_psi_zero;
-            psi.minus[j + i * psi.grid.ny] = new_psi_minus;
+            psi.plus[j + i * psi.grid.m_yPoints] = new_psi_plus;
+            psi.zero[j + i * psi.grid.m_yPoints] = new_psi_zero;
+            psi.minus[j + i * psi.grid.m_yPoints] = new_psi_minus;
 
         }
     }
@@ -139,7 +139,7 @@ void interaction_step(Wavefunction2D &psi, const Parameters &params, const doubl
 void interaction_step(Wavefunction1D &psi, const Parameters &params, const std::vector<double> &V)
 {
 #pragma omp parallel for shared(psi, params, I, V) default(none)
-    for (int i = 0; i < psi.grid.nx; ++i)
+    for (int i = 0; i < psi.grid.m_xPoints; ++i)
     {
         // Calculate spin vector elements
         std::complex<double> f_perp =
@@ -189,13 +189,13 @@ void renormalise_atom_num(Wavefunction2D &psi)
     double current_N_zero = psi.component_atom_number("zero");
     double current_N_minus = psi.component_atom_number("minus");
 
-    for (int i = 0; i < psi.grid.nx; ++i)
+    for (int i = 0; i < psi.grid.m_xPoints; ++i)
     {
-        for (int j = 0; j < psi.grid.ny; ++j)
+        for (int j = 0; j < psi.grid.m_yPoints; ++j)
         {
-            psi.plus[j + i * psi.grid.ny] *= sqrt(psi.N_plus) / sqrt(current_N_plus);
-            psi.zero[j + i * psi.grid.ny] *= sqrt(psi.N_zero) / sqrt(current_N_zero);
-            psi.minus[j + i * psi.grid.ny] *= sqrt(psi.N_minus) / sqrt(current_N_minus);
+            psi.plus[j + i * psi.grid.m_yPoints] *= sqrt(psi.N_plus) / sqrt(current_N_plus);
+            psi.zero[j + i * psi.grid.m_yPoints] *= sqrt(psi.N_zero) / sqrt(current_N_zero);
+            psi.minus[j + i * psi.grid.m_yPoints] *= sqrt(psi.N_minus) / sqrt(current_N_minus);
         }
     }
 }
@@ -206,7 +206,7 @@ void renormalise_atom_num(Wavefunction1D &psi)
     double current_N_zero = psi.component_atom_number("zero");
     double current_N_minus = psi.component_atom_number("minus");
 
-    for (int i = 0; i < psi.grid.nx; ++i)
+    for (int i = 0; i < psi.grid.m_xPoints; ++i)
     {
         psi.plus[i] *= sqrt(psi.N_plus) / sqrt(current_N_plus);
         psi.zero[i] *= sqrt(psi.N_zero) / sqrt(current_N_zero);

--- a/include/grid.h
+++ b/include/grid.h
@@ -1,7 +1,3 @@
-//
-// Created by mattw on 04/01/2022.
-//
-
 #ifndef BECPP_GRID_H
 #define BECPP_GRID_H
 
@@ -10,80 +6,82 @@
 
 using doubleArray_t = std::vector<std::vector<double>>;
 
-class Grid1D
+class Grid
+{
+protected:
+    virtual void constructGridParams() = 0;
+    virtual void constructGrids() = 0;
+    virtual void fftshift() = 0;
+    virtual ~Grid() = default;
+};
+
+class Grid1D : public Grid
 {
 private:
-    // Grid2D & parameter construction functions
-    void construct_grid_params();
+    void constructGridParams() override;
+    void constructGrids() override;
+    void fftshift() override;
 
-    void construct_grids();
+    const unsigned int m_xPoints{};
+    double m_xGridSpacing{};
+    double m_xFourierGridSpacing{};
+    double m_xLength{};
 
-    void fftshift();
+    std::vector<double> m_xMesh{};
+    std::vector<double> m_xFourierMesh{};
+    std::vector<double> m_wavenumber{};
 
 public:
-    // Grid1D points
-    const unsigned int nx{};
-
-    // Grid1D spacing
-    double dx{};
-    double dkx{};
-
-    // Grid1D lengths
-    double len_x{};
-    double len_y{};
-
-    // Grids
-    std::vector<double> X{};
-    std::vector<double> Kx{};
-    std::vector<double> K{};
-
-    // Constructors
     Grid1D(unsigned int nx, double dx);
+    ~Grid1D() override = default;
 
-    Grid1D(const Grid1D &grid);  // Copy constructor
+    [[nodiscard]] unsigned int xPoints() const;
+    [[nodiscard]] double xGridSpacing() const;
+    [[nodiscard]] double xFourierGridSpacing() const;
+    [[nodiscard]] double xLength() const;
+    [[nodiscard]] std::vector<double> wavenumber() const;
 
-    // Declare wavefunction class a friend
     friend class Wavefunction;
 };
 
-class Grid2D
+class Grid2D : public Grid
 {
 private:
-    // Grid2D & parameter construction functions
-    void construct_grid_params();
+    void constructGridParams() override;
+    void constructGrids() override;
+    void fftshift() override;
 
-    void construct_grids();
+    const unsigned int m_xPoints{};
+    const unsigned int m_yPoints{};
+    double m_xGridSpacing{};
+    double m_yGridSpacing{};
+    double m_gridSpacingProduct{};
+    double m_xFourierGridSpacing{};
+    double m_yFourierGridSpacing{};
+    double m_xLength{};
+    double m_yLength{};
 
-    void fftshift();
+    doubleArray_t m_xMesh{};
+    doubleArray_t m_yMesh{};
+    doubleArray_t m_xFourierMesh{};
+    doubleArray_t m_yFourierMesh{};
+    doubleArray_t m_wavenumber{};
 
 public:
-    // Grid2D points
-    const unsigned int nx{};
-    const unsigned int ny{};
-
-    // Grid2D spacing
-    double dx{};
-    double dy{};
-    double dkx{};
-    double dky{};
-
-    // Grid2D lengths
-    double len_x{};
-    double len_y{};
-
-    // Grids
-    doubleArray_t X{};
-    doubleArray_t Y{};
-    doubleArray_t Kx{};
-    doubleArray_t Ky{};
-    doubleArray_t K{};
-
-    // Constructors
     Grid2D(unsigned int nx, unsigned int ny, double dx, double dy);
+    ~Grid2D() override = default;
 
-    Grid2D(const Grid2D &grid);  // Copy constructor
+    [[nodiscard]] unsigned int xPoints() const;
+    [[nodiscard]] unsigned int yPoints() const;
+    [[nodiscard]] double xGridSpacing() const;
+    [[nodiscard]] double yGridSpacing() const;
+    [[nodiscard]] double gridSpacingProduct() const;
+    [[nodiscard]] double xFourierGridSpacing() const;
+    [[nodiscard]] double yFourierGridSpacing() const;
+    [[nodiscard]] double xLength() const;
+    [[nodiscard]] double yLength() const;
+    [[nodiscard]] doubleArray_t wavenumber() const;
 
-    // Declare wavefunction class a friend
     friend class Wavefunction;
 };
 

--- a/include/phase.h
+++ b/include/phase.h
@@ -30,7 +30,7 @@ std::vector<std::tuple<double, double>> generate_positions(const int n_vort, con
     // Construct random generator
     unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
     std::default_random_engine generator(seed);
-    std::uniform_real_distribution<double> uniform_distribution(-grid.len_x / 2, grid.len_x / 2);
+    std::uniform_real_distribution<double> uniform_distribution(-grid.m_xLength / 2, grid.m_xLength / 2);
 
     while (positions.size() < n_vort)
     {
@@ -80,29 +80,29 @@ doubleArray_t construct_phase(const int n_vort, const double threshold, const Gr
 
     // Phase array
     doubleArray_t theta;
-    theta.resize(grid.nx, std::vector<double>(grid.ny));
+    theta.resize(grid.m_xPoints, std::vector<double>(grid.m_yPoints));
 
     for (int num = 0; num < n_vort / 2; ++num)
     {
         doubleArray_t theta_k;
-        theta_k.resize(grid.nx, std::vector<double>(grid.ny));
+        theta_k.resize(grid.m_xPoints, std::vector<double>(grid.m_yPoints));
 
         // Extract positions
         auto[x_m, y_m] = positions[num];
         auto[x_p, y_p] = positions[n_vort / 2 + num];
 
-        double x_m_tilde = 2 * PI * ((x_m + grid.len_x) / grid.len_x);
-        double y_m_tilde = 2 * PI * ((y_m + grid.len_y) / grid.len_y);
-        double x_p_tilde = 2 * PI * ((x_p + grid.len_x) / grid.len_x);
-        double y_p_tilde = 2 * PI * ((y_p + grid.len_y) / grid.len_y);
+        double x_m_tilde = 2 * PI * ((x_m + grid.m_xLength) / grid.m_xLength);
+        double y_m_tilde = 2 * PI * ((y_m + grid.m_yLength) / grid.m_yLength);
+        double x_p_tilde = 2 * PI * ((x_p + grid.m_xLength) / grid.m_xLength);
+        double y_p_tilde = 2 * PI * ((y_p + grid.m_yLength) / grid.m_yLength);
 
 #pragma omp parallel for collapse(2) shared(grid, theta, theta_k, y_m_tilde, x_m_tilde, y_p_tilde, x_p_tilde) default(none)
-        for (int i = 0; i < grid.nx; ++i)
+        for (int i = 0; i < grid.m_xPoints; ++i)
         {
-            for (int j = 0; j < grid.ny; ++j)
+            for (int j = 0; j < grid.m_yPoints; ++j)
             {
-                double x_tilde = 2 * PI * ((grid.X[i][j] + grid.len_x) / grid.len_x);
-                double y_tilde = 2 * PI * ((grid.Y[i][j] + grid.len_x) / grid.len_x);
+                double x_tilde = 2 * PI * ((grid.m_xMesh[i][j] + grid.m_xLength) / grid.m_xLength);
+                double y_tilde = 2 * PI * ((grid.m_yMesh[i][j] + grid.m_xLength) / grid.m_xLength);
 
                 // Aux variables
                 double Y_minus = y_tilde - y_m_tilde;

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -35,26 +35,26 @@ void DataManager::save_parameters(const Parameters &params, const Grid2D &grid)
     file.createDataSet("/time/dt", params.dt.real());
 
     // Save grid parameters to file
-    file.createDataSet("/grid/nx", grid.nx);
-    file.createDataSet("/grid/ny", grid.ny);
-    file.createDataSet("/grid/dx", grid.dx);
-    file.createDataSet("/grid/dy", grid.dy);
+    file.createDataSet("/grid/m_xPoints", grid.m_xPoints);
+    file.createDataSet("/grid/m_yPoints", grid.m_yPoints);
+    file.createDataSet("/grid/m_xGridSpacing", grid.m_xGridSpacing);
+    file.createDataSet("/grid/m_yGridSpacing", grid.m_yGridSpacing);
 
 }
 
 void DataManager::generate_wfn_datasets(const Grid2D &grid)
 {
     // Define dataspaces with arbitrary length of last dimension
-    HighFive::DataSpace ds_plus = HighFive::DataSpace({grid.nx * grid.ny, 1},
-                                                      {grid.nx * grid.ny, HighFive::DataSpace::UNLIMITED});
-    HighFive::DataSpace ds_zero = HighFive::DataSpace({grid.nx * grid.ny, 1},
-                                                      {grid.nx * grid.ny, HighFive::DataSpace::UNLIMITED});
-    HighFive::DataSpace ds_minus = HighFive::DataSpace({grid.nx * grid.ny, 1},
-                                                       {grid.nx * grid.ny, HighFive::DataSpace::UNLIMITED});
+    HighFive::DataSpace ds_plus = HighFive::DataSpace({grid.m_xPoints * grid.m_yPoints, 1},
+                                                      {grid.m_xPoints * grid.m_yPoints, HighFive::DataSpace::UNLIMITED});
+    HighFive::DataSpace ds_zero = HighFive::DataSpace({grid.m_xPoints * grid.m_yPoints, 1},
+                                                      {grid.m_xPoints * grid.m_yPoints, HighFive::DataSpace::UNLIMITED});
+    HighFive::DataSpace ds_minus = HighFive::DataSpace({grid.m_xPoints * grid.m_yPoints, 1},
+                                                       {grid.m_xPoints * grid.m_yPoints, HighFive::DataSpace::UNLIMITED});
 
     // Use chunking
     HighFive::DataSetCreateProps props;
-    props.add(HighFive::Chunking(std::vector<hsize_t>{(grid.nx * grid.ny) / 4, 1}));
+    props.add(HighFive::Chunking(std::vector<hsize_t>{(grid.m_xPoints * grid.m_yPoints) / 4, 1}));
 
     // Create wavefunction datasets
     file.createDataSet("/wavefunction/psi_plus", ds_plus,
@@ -74,17 +74,17 @@ void DataManager::save_wavefunction_data(Wavefunction2D &psi)
     HighFive::DataSet ds_minus = file.getDataSet("/wavefunction/psi_minus");
 
     // Resize datasets
-    ds_plus.resize({psi.grid.nx * psi.grid.ny, save_index + 1});
-    ds_zero.resize({psi.grid.nx * psi.grid.ny, save_index + 1});
-    ds_minus.resize({psi.grid.nx * psi.grid.ny, save_index + 1});
+    ds_plus.resize({psi.grid.m_xPoints * psi.grid.m_yPoints, save_index + 1});
+    ds_zero.resize({psi.grid.m_xPoints * psi.grid.m_yPoints, save_index + 1});
+    ds_minus.resize({psi.grid.m_xPoints * psi.grid.m_yPoints, save_index + 1});
 
     // FFT so we update real-space arrays
     psi.ifft();
 
     // Save new wavefunction data
-    ds_plus.select({0, save_index}, {psi.grid.nx * psi.grid.ny, 1}).write(psi.plus);
-    ds_zero.select({0, save_index}, {psi.grid.nx * psi.grid.ny, 1}).write(psi.zero);
-    ds_minus.select({0, save_index}, {psi.grid.nx * psi.grid.ny, 1}).write(psi.minus);
+    ds_plus.select({0, save_index}, {psi.grid.m_xPoints * psi.grid.m_yPoints, 1}).write(psi.plus);
+    ds_zero.select({0, save_index}, {psi.grid.m_xPoints * psi.grid.m_yPoints, 1}).write(psi.zero);
+    ds_minus.select({0, save_index}, {psi.grid.m_xPoints * psi.grid.m_yPoints, 1}).write(psi.minus);
 
     // Increase save index
     save_index += 1;

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -32,8 +32,6 @@ void Grid2D::constructGrids()
             m_xFourierMesh[i][j] = (j - m_xPoints / 2.) * m_xFourierGridSpacing;
             m_yMesh[j][i] = (j - m_yPoints / 2.) * m_yGridSpacing;
             m_yFourierMesh[j][i] = (j - m_yPoints / 2.) * m_yFourierGridSpacing;
-            m_wavenumber[i][j] = std::pow(m_xFourierMesh[i][j], 2) +
-                                 std::pow(m_yFourierMesh[i][j], 2);
         }
     }
 
@@ -132,7 +130,6 @@ void Grid1D::constructGrids()
     {
         m_xMesh[i] = (i - m_xPoints / 2.) * m_xGridSpacing;
         m_xFourierMesh[i] = (i - m_xPoints / 2.) * m_xFourierGridSpacing;
-        m_wavenumber[i] = std::pow(m_xFourierMesh[i], 2);
     }
 
     // Shift the k-space grids, so they are in the right order
@@ -150,7 +147,11 @@ void Grid1D::fftshift()
     std::ranges::rotate(m_xFourierMesh.begin(),
                         m_xFourierMesh.begin() + m_xPoints / 2,
                         m_xFourierMesh.end());
-    m_wavenumber = m_xFourierMesh;
+
+    for (int i = 0; i < m_xPoints; ++i)
+    {
+        m_wavenumber[i] = std::pow(m_xFourierMesh[i], 2);
+    }
 }
 unsigned int Grid1D::xPoints() const { return m_xPoints; }
 double Grid1D::xGridSpacing() const { return m_xGridSpacing; }

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -1,42 +1,39 @@
-//
-// Created by mattw on 04/01/2022.
-//
-
-#include <cmath>
-#include <algorithm>
 #include "grid.h"
 #include "constants.h"
+#include <algorithm>
+#include <cmath>
 
-void Grid2D::construct_grid_params()
+void Grid2D::constructGridParams()
 {
     // Calculate k-space grid spacing
-    dkx = PI / (nx / 2. * dx);
-    dky = PI / (ny / 2. * dy);
+    m_xFourierGridSpacing = PI / (m_xPoints / 2. * m_xGridSpacing);
+    m_yFourierGridSpacing = PI / (m_yPoints / 2. * m_yGridSpacing);
 
     // Sets length of sides of box
-    len_x = nx * dx;
-    len_y = ny * dy;
+    m_xLength = m_xPoints * m_xGridSpacing;
+    m_yLength = m_yPoints * m_yGridSpacing;
 }
 
-void Grid2D::construct_grids()
+void Grid2D::constructGrids()
 {
     // Set grid sizes
-    X.resize(nx, std::vector<double>(ny));
-    Y.resize(nx, std::vector<double>(ny));
-    Kx.resize(nx, std::vector<double>(ny));
-    Ky.resize(nx, std::vector<double>(ny));
-    K.resize(nx, std::vector<double>(ny));
+    m_xMesh.resize(m_xPoints, std::vector<double>(m_yPoints));
+    m_yMesh.resize(m_xPoints, std::vector<double>(m_yPoints));
+    m_xFourierMesh.resize(m_xPoints, std::vector<double>(m_yPoints));
+    m_yFourierMesh.resize(m_xPoints, std::vector<double>(m_yPoints));
+    m_wavenumber.resize(m_xPoints, std::vector<double>(m_yPoints));
 
     // Construct grids
-    for (int i = 0; i < nx; ++i)
+    for (int i = 0; i < m_xPoints; ++i)
     {
-        for (int j = 0; j < ny; ++j)
+        for (int j = 0; j < m_yPoints; ++j)
         {
-            X[i][j] = (j - nx / 2.) * dx;
-            Kx[i][j] = (j - nx / 2.) * dkx;
-            Y[j][i] = (j - ny / 2.) * dy;
-            Ky[j][i] = (j - ny / 2.) * dky;
-            K[i][j] = std::pow(Kx[i][j], 2) + std::pow(Ky[i][j], 2);
+            m_xMesh[i][j] = (j - m_xPoints / 2.) * m_xGridSpacing;
+            m_xFourierMesh[i][j] = (j - m_xPoints / 2.) * m_xFourierGridSpacing;
+            m_yMesh[j][i] = (j - m_yPoints / 2.) * m_yGridSpacing;
+            m_yFourierMesh[j][i] = (j - m_yPoints / 2.) * m_yFourierGridSpacing;
+            m_wavenumber[i][j] = std::pow(m_xFourierMesh[i][j], 2) +
+                                 std::pow(m_yFourierMesh[i][j], 2);
         }
     }
 
@@ -46,122 +43,117 @@ void Grid2D::construct_grids()
 
 void Grid2D::fftshift()
 {
-    /*
-        Shifts the zero-frequency component to the center
-        of the spectrum.
-    */
-
-    /*
-        This is a poor implementation.
-        It would be nice to make use of std::rotate in a future implementation.
-    */
-
-    std::vector<std::vector<double>> Kx_copy = Kx;
-    std::vector<std::vector<double>> Ky_copy = Ky;
+    std::vector<std::vector<double>> Kx_copy = m_xFourierMesh;
+    std::vector<std::vector<double>> Ky_copy = m_yFourierMesh;
 
     // Reverse each row
-    for (int i = 0; i < nx; i++)
+    for (int i = 0; i < m_xPoints; i++)
     {
-        for (int j = 0; j < ny; j++)
+        for (int j = 0; j < m_yPoints; j++)
         {
-            if (j < nx / 2)
+            if (j < m_xPoints / 2)
             {
-                Kx[i][j] = Kx_copy[i][nx / 2 + j];
-                Ky[i][j] = Ky_copy[i][nx / 2 + j];
-            } else if (j >= nx / 2)
+                m_xFourierMesh[i][j] = Kx_copy[i][m_xPoints / 2 + j];
+                m_yFourierMesh[i][j] = Ky_copy[i][m_xPoints / 2 + j];
+            } else if (j >= m_xPoints / 2)
             {
-                Kx[i][j] = Kx_copy[i][j - nx / 2];
-                Ky[i][j] = Ky_copy[i][j - nx / 2];
+                m_xFourierMesh[i][j] = Kx_copy[i][j - m_xPoints / 2];
+                m_yFourierMesh[i][j] = Ky_copy[i][j - m_xPoints / 2];
             }
         }
     }
 
     // Update copy arrays
-    Kx_copy = Kx;
-    Ky_copy = Ky;
+    Kx_copy = m_xFourierMesh;
+    Ky_copy = m_yFourierMesh;
 
     // Reverse each column
-    for (int i = 0; i < nx; i++)
+    for (int i = 0; i < m_xPoints; i++)
     {
-        for (int j = 0; j < ny; j++)
+        for (int j = 0; j < m_yPoints; j++)
         {
-            if (j < nx / 2)
+            if (j < m_xPoints / 2)
             {
-                Kx[j][i] = Kx_copy[nx / 2 + j][i];
-                Ky[j][i] = Ky_copy[nx / 2 + j][i];
-            } else if (j >= nx / 2)
+                m_xFourierMesh[j][i] = Kx_copy[m_xPoints / 2 + j][i];
+                m_yFourierMesh[j][i] = Ky_copy[m_xPoints / 2 + j][i];
+            } else if (j >= m_xPoints / 2)
             {
-                Kx[j][i] = Kx_copy[j - nx / 2][i];
-                Ky[j][i] = Ky_copy[j - nx / 2][i];
+                m_xFourierMesh[j][i] = Kx_copy[j - m_xPoints / 2][i];
+                m_yFourierMesh[j][i] = Ky_copy[j - m_xPoints / 2][i];
             }
         }
     }
 
-    // Update wavevector
-    for (int i = 0; i < nx; ++i)
+    // Update wave vector
+    for (int i = 0; i < m_xPoints; ++i)
     {
-        for (int j = 0; j < ny; ++j)
+        for (int j = 0; j < m_yPoints; ++j)
         {
-            K[i][j] = std::pow(Kx[i][j], 2) + std::pow(Ky[i][j], 2);
+            m_wavenumber[i][j] = std::pow(m_xFourierMesh[i][j], 2) +
+                                 std::pow(m_yFourierMesh[i][j], 2);
         }
     }
 }
 
 Grid2D::Grid2D(unsigned int nx, unsigned int ny, double dx, double dy)
-        : nx{nx}, ny{ny}, dx{dx}, dy{dy}
+    : m_xPoints{nx}, m_yPoints{ny}, m_xGridSpacing{dx}, m_yGridSpacing{dy},
+      m_gridSpacingProduct{dx * dy}
 {
-    construct_grid_params();
-    construct_grids();
+    Grid2D::constructGridParams();
+    Grid2D::constructGrids();
 }
 
-Grid2D::Grid2D(const Grid2D &grid) : nx{grid.nx}, ny{grid.ny}, dx{grid.dx}, dy{grid.dy}
+unsigned int Grid2D::xPoints() const { return m_xPoints; }
+unsigned int Grid2D::yPoints() const { return m_yPoints; }
+double Grid2D::xGridSpacing() const { return m_xGridSpacing; }
+double Grid2D::yGridSpacing() const { return m_yGridSpacing; }
+double Grid2D::gridSpacingProduct() const { return m_gridSpacingProduct; }
+double Grid2D::xFourierGridSpacing() const { return m_xFourierGridSpacing; }
+double Grid2D::yFourierGridSpacing() const { return m_yFourierGridSpacing; }
+double Grid2D::xLength() const { return m_xLength; }
+double Grid2D::yLength() const { return m_yLength; }
+doubleArray_t Grid2D::wavenumber() const { return m_wavenumber; }
+
+void Grid1D::constructGridParams()
 {
-    construct_grid_params();
-    construct_grids();
+    m_xFourierGridSpacing = PI / (m_xPoints / 2. * m_xGridSpacing);
+    m_xLength = m_xPoints * m_xGridSpacing;
 }
 
-void Grid1D::construct_grid_params()
-{
-    // Calculate k-space grid spacing
-    dkx = PI / (nx / 2. * dx);
-
-    // Sets length of side of box
-    len_x = nx * dx;
-}
-
-void Grid1D::construct_grids()
+void Grid1D::constructGrids()
 {
     // Set grid sizes
-    X.resize(nx);
-    Kx.resize(nx);
-    K.resize(nx);
+    m_xMesh.resize(m_xPoints);
+    m_xFourierMesh.resize(m_xPoints);
+    m_wavenumber.resize(m_xPoints);
 
     // Construct grids
-    for (int i = 0; i < nx; ++i)
+    for (int i = 0; i < m_xPoints; ++i)
     {
-        X[i] = (i - nx / 2.) * dx;
-        Kx[i] = (i - nx / 2.) * dkx;
-        K[i] = std::pow(Kx[i], 2);
+        m_xMesh[i] = (i - m_xPoints / 2.) * m_xGridSpacing;
+        m_xFourierMesh[i] = (i - m_xPoints / 2.) * m_xFourierGridSpacing;
+        m_wavenumber[i] = std::pow(m_xFourierMesh[i], 2);
     }
 
     // Shift the k-space grids, so they are in the right order
     fftshift();
 }
 
-Grid1D::Grid1D(unsigned int nx, double dx) : nx{nx}, dx{dx}
+Grid1D::Grid1D(unsigned int nx, double dx) : m_xPoints{nx}, m_xGridSpacing{dx}
 {
-    construct_grid_params();
-    construct_grids();
-}
-
-Grid1D::Grid1D(const Grid1D &grid) : nx{grid.nx}, dx{grid.dx}
-{
-    construct_grid_params();
-    construct_grids();
+    Grid1D::constructGridParams();
+    Grid1D::constructGrids();
 }
 
 void Grid1D::fftshift()
 {
-    std::rotate(Kx.begin(), Kx.begin() + nx / 2, Kx.end());
-    K = Kx;
+    std::ranges::rotate(m_xFourierMesh.begin(),
+                        m_xFourierMesh.begin() + m_xPoints / 2,
+                        m_xFourierMesh.end());
+    m_wavenumber = m_xFourierMesh;
 }
+unsigned int Grid1D::xPoints() const { return m_xPoints; }
+double Grid1D::xGridSpacing() const { return m_xGridSpacing; }
+double Grid1D::xFourierGridSpacing() const { return m_xFourierGridSpacing; }
+double Grid1D::xLength() const { return m_xLength; }
+std::vector<double> Grid1D::wavenumber() const { return m_wavenumber; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.21)
+set(CMAKE_CXX_STANDARD 20)
+
+include(FetchContent)
+FETCHCONTENT_DECLARE(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+set(SOURCE_FILES test_grid.cpp)
+
+enable_testing()
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+add_executable(tests
+        ${SOURCE_FILES}
+)
+target_link_libraries(tests
+        BECpp
+        GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(tests)

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include "grid.h"
+#include "constants.h"
+
+class Grid1DTest : public ::testing::Test
+{
+public:
+    Grid1D grid{128, 0.5};
+};
+
+TEST_F(Grid1DTest, PointsSetCorrectly)
+{
+    ASSERT_EQ(grid.xPoints(), 128);
+}
+
+TEST_F(Grid1DTest, SpacingSetCorrectly)
+{
+    ASSERT_EQ(grid.xGridSpacing(), 0.5);
+}
+
+TEST_F(Grid1DTest, FourierSpacingSetCorrectly)
+{
+    ASSERT_EQ(grid.xFourierGridSpacing(), PI / 32.0);
+}
+
+TEST_F(Grid1DTest, LengthSetCorrectly)
+{
+    ASSERT_EQ(grid.xLength(), 64);
+}
+
+TEST_F(Grid1DTest, WavenumberSetCorrectly)
+{
+    ASSERT_EQ(grid.wavenumber()[0], 0.0);
+}
+
+class Grid2DTest : public ::testing::Test
+{
+public:
+    Grid2D grid{128, 128, 0.5, 0.5};
+};
+
+TEST_F(Grid2DTest, PointsSetCorrectly)
+{
+    ASSERT_EQ(grid.xPoints(), 128);
+    ASSERT_EQ(grid.yPoints(), 128);
+}
+
+TEST_F(Grid2DTest, SpacingSetCorrectly)
+{
+    ASSERT_EQ(grid.xGridSpacing(), 0.5);
+    ASSERT_EQ(grid.yGridSpacing(), 0.5);
+}
+
+TEST_F(Grid2DTest, FourierSpacingSetCorrectly)
+{
+    ASSERT_EQ(grid.xFourierGridSpacing(), PI / 32.0);
+    ASSERT_EQ(grid.yFourierGridSpacing(), PI / 32.0);
+}
+
+TEST_F(Grid2DTest, LengthSetCorrectly)
+{
+    ASSERT_EQ(grid.xLength(), 64);
+    ASSERT_EQ(grid.yLength(), 64);
+}
+
+TEST_F(Grid2DTest, WavenumberSetCorrectly)
+{
+    ASSERT_EQ(grid.wavenumber()[0][0], 0.0);
+}


### PR DESCRIPTION
### Changes
This PR brings the addition of an abstract `Grid` base class in which grids of different dimensionality derive from. Additionally, it provides a complete refactor of the existing `Grid` classes, including better encapsulation.