### PR TITLE
Bec 2 fix cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,5 @@
 cmake-build-debug
 cmake-build-debug-coverage
 .idea
-lib
 data
 python_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.21..3.26)
 project(BECpp)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -7,12 +7,37 @@ set(SOURCES src/grid.cpp)
 set(INCLUDES include/constants.h include/grid.h)
 
 find_package(OpenMP REQUIRED)
+find_package(HDF5 REQUIRED)
+find_package(HighFive REQUIRED)
+
+configure_file(downloadFindFFTW.cmake.in findFFTW-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/findFFTW-download )
+if(result)
+    message(FATAL_ERROR "CMake step for findFFTW failed: ${result}")
+else()
+    message("CMake step for findFFTW completed (${result}).")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/findFFTW-download )
+if(result)
+    message(FATAL_ERROR "Build step for findFFTW failed: ${result}")
+endif()
+
+set(findFFTW_DIR ${CMAKE_CURRENT_BINARY_DIR}/findFFTW-src)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${findFFTW_DIR}")
+find_package(FFTW REQUIRED)
 
 add_library(${PROJECT_NAME} STATIC ${SOURCES} ${INCLUDES})
 
 target_include_directories(${PROJECT_NAME} PRIVATE
         ${PROJECT_SOURCE_DIR}/include/)
-target_link_libraries(${PROJECT_NAME} OpenMP::OpenMP_CXX)
+target_link_libraries(${PROJECT_NAME}
+        OpenMP::OpenMP_CXX
+        hdf5::hdf5
+        HighFive)
 
 enable_testing()
 add_subdirectory(test)

--- a/downloadFindFFTW.cmake.in
+++ b/downloadFindFFTW.cmake.in
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(findFFTW-download NONE)
+
+include(ExternalProject)
+
+ExternalProject_Add(findFFTW_download
+    GIT_REPOSITORY    "https://github.com/egpbos/findfftw.git"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   ""
+    TEST_COMMAND      ""
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/findFFTW-src"
+    BINARY_DIR        ""
+    INSTALL_DIR       ""
+)


### PR DESCRIPTION
This PR fixes issues with the CMakeLists.txt that prevented required libraries from being imported properly. It also provides a small file for finding FFTW on the system.