### PR TITLE
BEC-5 fftshift fixes

### DIFF
--- a/include/grid.h
+++ b/include/grid.h
@@ -13,15 +13,14 @@ class Grid
 protected:
     virtual void constructGridParams() = 0;
     virtual void constructMesh() = 0;
-    virtual void fftshift() = 0;
     virtual ~Grid() = default;
 };
 
 struct Mesh1D
 {
-    std::vector<double> m_xMesh{};
-    std::vector<double> m_xFourierMesh{};
-    std::vector<double> m_wavenumber{};
+    std::vector<double> xMesh{};
+    std::vector<double> xFourierMesh{};
+    std::vector<double> wavenumber{};
 };
 
 class Grid1D : public Grid
@@ -29,7 +28,6 @@ class Grid1D : public Grid
 private:
     void constructGridParams() override;
     void constructMesh() override;
-    void fftshift() override;
 
     const unsigned int m_gridPoints{};
     double m_gridSpacing{};
@@ -64,7 +62,6 @@ class Grid2D : public Grid
 private:
     void constructGridParams() override;
     void constructMesh() override;
-    void fftshift() override;
 
     const std::tuple<unsigned int, unsigned int> m_gridPoints{};
     const std::tuple<double, double> m_gridSpacing{};
@@ -102,7 +99,6 @@ class Grid3D : public Grid
 private:
     void constructGridParams() override;
     void constructMesh() override;
-    void fftshift() override;
 
     const std::tuple<unsigned int, unsigned int, unsigned int> m_gridPoints{};
     const std::tuple<double, double, double> m_gridSpacing{};

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -18,30 +18,25 @@ void Grid1D::constructGridParams()
 
 void Grid1D::constructMesh()
 {
-    m_mesh.m_xMesh.resize(m_gridPoints);
-    m_mesh.m_xFourierMesh.resize(m_gridPoints);
-    m_mesh.m_wavenumber.resize(m_gridPoints);
+    auto xPoints = shape();
+    auto xGridSpacing = gridSpacing();
+    auto xFourierGridSpacing = fourierGridSpacing();
+    m_mesh.xMesh.resize(xPoints);
+    m_mesh.xFourierMesh.resize(xPoints);
+    m_mesh.wavenumber.resize(xPoints);
 
-    for (int i = 0; i < m_gridPoints; ++i)
+    for (int i = 0; i < xPoints; ++i)
     {
-        m_mesh.m_xMesh[i] = (i - m_gridPoints / 2.) * m_gridSpacing;
-        m_mesh.m_xFourierMesh[i] =
-                (i - m_gridPoints / 2.) * m_fourierGridSpacing;
-    }
+        m_mesh.xMesh[i] = (i - xPoints / 2.) * xGridSpacing;
+        if (i < xPoints / 2)
+        {
+            m_mesh.xFourierMesh[i] = i * xFourierGridSpacing;
+        } else
+        {
+            m_mesh.xFourierMesh[i] = (i - xPoints) * xFourierGridSpacing;
+        }
 
-    // Shift the k-space grids, so they are in the right order
-    fftshift();
-}
-
-void Grid1D::fftshift()
-{
-    std::ranges::rotate(m_mesh.m_xFourierMesh.begin(),
-                        m_mesh.m_xFourierMesh.begin() + m_gridPoints / 2,
-                        m_mesh.m_xFourierMesh.end());
-
-    for (int i = 0; i < m_gridPoints; ++i)
-    {
-        m_mesh.m_wavenumber[i] = std::pow(m_mesh.m_xFourierMesh[i], 2);
+        m_mesh.wavenumber[i] = std::pow(m_mesh.xFourierMesh[i], 2);
     }
 }
 
@@ -53,7 +48,7 @@ double Grid1D::fourierGridSpacing() const { return m_fourierGridSpacing; }
 
 double Grid1D::gridLength() const { return m_length; }
 
-std::vector<double> Grid1D::wavenumber() const { return m_mesh.m_wavenumber; }
+std::vector<double> Grid1D::wavenumber() const { return m_mesh.wavenumber; }
 
 Grid2D::Grid2D(std::tuple<unsigned int, unsigned int> points,
                std::tuple<double, double> gridSpacing)
@@ -77,7 +72,7 @@ void Grid2D::constructMesh()
 {
     auto [xPoints, yPoints] = shape();
     auto [xGridSpacing, yGridSpacing] = gridSpacing();
-    auto[xFourierGridSpacing, yFourierGridSpacing] = fourierGridSpacing();
+    auto [xFourierGridSpacing, yFourierGridSpacing] = fourierGridSpacing();
 
     m_mesh.xMesh.resize(xPoints, std::vector<double>(yPoints));
     m_mesh.yMesh.resize(xPoints, std::vector<double>(yPoints));
@@ -90,21 +85,22 @@ void Grid2D::constructMesh()
         for (int j = 0; j < yPoints; ++j)
         {
             m_mesh.xMesh[i][j] = (j - xPoints / 2.) * xGridSpacing;
-            m_mesh.xFourierMesh[i][j] =
-                    (j - xPoints / 2.) * xFourierGridSpacing;
-            m_mesh.yMesh[j][i] = (j - yPoints / 2.) * yGridSpacing;
-            m_mesh.yFourierMesh[j][i] =
-                    (j - yPoints / 2.) * yFourierGridSpacing;
+            m_mesh.yMesh[i][j] = (j - yPoints / 2.) * yGridSpacing;
+            if (i < xPoints / 2)
+            {
+                m_mesh.xFourierMesh[i][j] = i * xFourierGridSpacing;
+                m_mesh.yFourierMesh[i][j] = j * yFourierGridSpacing;
+            } else
+            {
+                m_mesh.xFourierMesh[i][j] = (i - xPoints) * xFourierGridSpacing;
+                m_mesh.yFourierMesh[i][j] = (j - yPoints) * yFourierGridSpacing;
+            }
+
+            m_mesh.wavenumber[i][j] =
+                    std::pow(m_mesh.xFourierMesh[i][j], 2) +
+                    std::pow(m_mesh.yFourierMesh[i][j], 2);
         }
     }
-
-    // Shift the k-space grids, so they are in the right order
-    fftshift();
-}
-
-void Grid2D::fftshift()
-{
-    // To implement
 }
 
 std::tuple<unsigned int, unsigned int> Grid2D::shape() const
@@ -165,32 +161,38 @@ void Grid3D::constructMesh()
     m_mesh.wavenumber.resize(xPoints,
                              vector2D_t(yPoints, std::vector<double>(zPoints)));
 
-    for (int i = 0; i < xPoints; ++i)
+    for (int k = 0; k < zPoints; ++k)
     {
         for (int j = 0; j < yPoints; ++j)
         {
-            for (int k = 0; k < zPoints; ++k)
+            for (int i = 0; i < xPoints; ++i)
             {
-                m_mesh.xMesh[i][j][k] = (j - xPoints / 2.) * xGridSpacing;
-                m_mesh.xFourierMesh[i][j][k] =
-                        (j - xPoints / 2.) * xFourierGridSpacing;
-                m_mesh.yMesh[j][i][k] = (j - yPoints / 2.) * yGridSpacing;
-                m_mesh.yFourierMesh[j][i][k] =
-                        (j - yPoints / 2.) * yFourierGridSpacing;
-                m_mesh.zMesh[k][j][i] = (k - zPoints / 2.) * zGridSpacing;
-                m_mesh.zFourierMesh[k][j][i] =
-                        (k - zPoints / 2.) * zFourierGridSpacing;
+                m_mesh.xMesh[i][j][k] = (i - xPoints / 2.) * xGridSpacing;
+                m_mesh.yMesh[i][j][k] = (j - yPoints / 2.) * yGridSpacing;
+                m_mesh.zMesh[i][j][k] = (k - zPoints / 2.) * zGridSpacing;
+
+                if (i < xPoints / 2)
+                {
+                    m_mesh.xFourierMesh[i][j][k] = i * xFourierGridSpacing;
+                    m_mesh.yFourierMesh[i][j][k] = j * yFourierGridSpacing;
+                    m_mesh.zFourierMesh[i][j][k] = k * yFourierGridSpacing;
+                } else
+                {
+                    m_mesh.xFourierMesh[i][j][k] =
+                            (i - xPoints) * xFourierGridSpacing;
+                    m_mesh.yFourierMesh[i][j][k] =
+                            (j - yPoints) * yFourierGridSpacing;
+                    m_mesh.zFourierMesh[i][j][k] =
+                            (k - zPoints) * yFourierGridSpacing;
+                }
+
+                m_mesh.wavenumber[i][j][k] =
+                        std::pow(m_mesh.xFourierMesh[i][j][k], 2) +
+                        std::pow(m_mesh.yFourierMesh[i][j][k], 2) +
+                        std::pow(m_mesh.zFourierMesh[i][j][k], 2);
             }
         }
     }
-
-    // Shift the k-space grids, so they are in the right order
-    fftshift();
-}
-
-void Grid3D::fftshift()
-{
-    // TODO: Implement using std::rotate
 }
 
 std::tuple<unsigned int, unsigned int, unsigned int> Grid3D::shape() const

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -16,14 +16,19 @@ void Grid1D::constructGridParams()
     m_length = m_gridPoints * m_gridSpacing;
 }
 
+void resizeMesh1D(Mesh1D mesh, unsigned int xPoints)
+{
+    mesh.xMesh.resize(xPoints);
+    mesh.xFourierMesh.resize(xPoints);
+    mesh.wavenumber.resize(xPoints);
+}
+
 void Grid1D::constructMesh()
 {
     auto xPoints = shape();
     auto xGridSpacing = gridSpacing();
     auto xFourierGridSpacing = fourierGridSpacing();
-    m_mesh.xMesh.resize(xPoints);
-    m_mesh.xFourierMesh.resize(xPoints);
-    m_mesh.wavenumber.resize(xPoints);
+    resizeMesh1D(m_mesh, xPoints);
 
     for (int i = 0; i < xPoints; ++i)
     {
@@ -68,17 +73,21 @@ void Grid2D::constructGridParams()
     m_gridLength = {xPoints * xGridSpacing, yPoints * yGridSpacing};
 }
 
+void resizeMesh2D(Mesh2D mesh, unsigned int xPoints, unsigned int yPoints)
+{
+    mesh.xMesh.resize(xPoints, std::vector<double>(yPoints));
+    mesh.yMesh.resize(xPoints, std::vector<double>(yPoints));
+    mesh.xFourierMesh.resize(xPoints, std::vector<double>(yPoints));
+    mesh.yFourierMesh.resize(xPoints, std::vector<double>(yPoints));
+    mesh.wavenumber.resize(xPoints, std::vector<double>(yPoints));
+}
+
 void Grid2D::constructMesh()
 {
     auto [xPoints, yPoints] = shape();
     auto [xGridSpacing, yGridSpacing] = gridSpacing();
     auto [xFourierGridSpacing, yFourierGridSpacing] = fourierGridSpacing();
-
-    m_mesh.xMesh.resize(xPoints, std::vector<double>(yPoints));
-    m_mesh.yMesh.resize(xPoints, std::vector<double>(yPoints));
-    m_mesh.xFourierMesh.resize(xPoints, std::vector<double>(yPoints));
-    m_mesh.yFourierMesh.resize(xPoints, std::vector<double>(yPoints));
-    m_mesh.wavenumber.resize(xPoints, std::vector<double>(yPoints));
+    resizeMesh2D(m_mesh, xPoints, yPoints);
 
     for (int i = 0; i < xPoints; ++i)
     {
@@ -139,27 +148,32 @@ void Grid3D::constructGridParams()
                     yPoints * zGridSpacing};
 }
 
+void resizeMesh3D(Mesh3D mesh, unsigned int xPoints, unsigned int yPoints, unsigned int zPoints)
+{
+    mesh.xMesh.resize(xPoints,
+                      vector2D_t(yPoints, std::vector<double>(zPoints)));
+    mesh.yMesh.resize(xPoints,
+                      vector2D_t(yPoints, std::vector<double>(zPoints)));
+    mesh.zMesh.resize(xPoints,
+                      vector2D_t(yPoints, std::vector<double>(zPoints)));
+    mesh.xFourierMesh.resize(
+            xPoints, vector2D_t(yPoints, std::vector<double>(zPoints)));
+    mesh.yFourierMesh.resize(
+            xPoints, vector2D_t(yPoints, std::vector<double>(zPoints)));
+    mesh.zFourierMesh.resize(
+            xPoints, vector2D_t(yPoints, std::vector<double>(zPoints)));
+    mesh.wavenumber.resize(xPoints,
+                           vector2D_t(yPoints, std::vector<double>(zPoints)));
+
+}
+
 void Grid3D::constructMesh()
 {
     auto [xPoints, yPoints, zPoints] = shape();
     auto [xGridSpacing, yGridSpacing, zGridSpacing] = gridSpacing();
     auto [xFourierGridSpacing, yFourierGridSpacing, zFourierGridSpacing] =
             fourierGridSpacing();
-
-    m_mesh.xMesh.resize(xPoints,
-                        vector2D_t(yPoints, std::vector<double>(zPoints)));
-    m_mesh.yMesh.resize(xPoints,
-                        vector2D_t(yPoints, std::vector<double>(zPoints)));
-    m_mesh.zMesh.resize(xPoints,
-                        vector2D_t(yPoints, std::vector<double>(zPoints)));
-    m_mesh.xFourierMesh.resize(
-            xPoints, vector2D_t(yPoints, std::vector<double>(zPoints)));
-    m_mesh.yFourierMesh.resize(
-            xPoints, vector2D_t(yPoints, std::vector<double>(zPoints)));
-    m_mesh.zFourierMesh.resize(
-            xPoints, vector2D_t(yPoints, std::vector<double>(zPoints)));
-    m_mesh.wavenumber.resize(xPoints,
-                             vector2D_t(yPoints, std::vector<double>(zPoints)));
+    resizeMesh3D(m_mesh, xPoints, yPoints, zPoints);
 
     for (int k = 0; k < zPoints; ++k)
     {

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -61,6 +61,11 @@ TEST_F(Grid2DTest, LengthSetCorrectly)
     ASSERT_EQ(yLength, 64);
 }
 
+TEST_F(Grid2DTest, WavenumberSetCorrectly)
+{
+    ASSERT_EQ(grid.wavenumber()[0][0], 0.0);
+}
+
 class Grid3DTest : public ::testing::Test
 {
 public:
@@ -100,4 +105,9 @@ TEST_F(Grid3DTest, LengthSetCorrectly)
     ASSERT_EQ(xLength, 32);
     ASSERT_EQ(yLength, 32);
     ASSERT_EQ(zLength, 32);
+}
+
+TEST_F(Grid3DTest, WavenumberSetCorrectly)
+{
+    ASSERT_EQ(grid.wavenumber()[0][0][0], 0.0);
 }


### PR DESCRIPTION
This PR brings with it correct functions to construct the meshgrid of the system.
Now, instead of providing an `fftshift()` function, Fourier space grids are built in the correct order for evolution.