### PR TITLE
Bec-7 Wavefunction redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,14 @@
 *.out
 *.app
 
+# Files
+CMakeSettings.json
+
 # Ignored directories
 cmake-build-debug
 cmake-build-debug-coverage
 .idea
 data
 python_tests
+.vs
+out/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME}
         OpenMP::OpenMP_CXX
         hdf5::hdf5
-        HighFive
         FFTW::Double)
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(BECpp)
 
 set(CMAKE_CXX_STANDARD 20)
 
-set(SOURCES src/grid.cpp)
-set(INCLUDES include/constants.h include/grid.h)
+set(SOURCES src/grid.cpp src/wavefunction.cpp)
+set(INCLUDES include/constants.h include/grid.h include/wavefunction.h)
 
 find_package(OpenMP REQUIRED)
 find_package(HDF5 REQUIRED)
@@ -37,11 +37,14 @@ find_package(FFTW REQUIRED)
 add_library(${PROJECT_NAME} STATIC ${SOURCES} ${INCLUDES})
 
 target_include_directories(${PROJECT_NAME} PRIVATE
-        ${PROJECT_SOURCE_DIR}/include/)
+        ${PROJECT_SOURCE_DIR}/include/
+        FFTW_INCLUDE_DIRS)
+
 target_link_libraries(${PROJECT_NAME}
         OpenMP::OpenMP_CXX
         hdf5::hdf5
-        HighFive)
+        HighFive
+        FFTW::Double)
 
 enable_testing()
 add_subdirectory(test)

--- a/include/grid.h
+++ b/include/grid.h
@@ -5,9 +5,6 @@
 #include <utility>
 #include <vector>
 
-using vector2D_t = std::vector<std::vector<double>>;
-using vector3D_t = std::vector<std::vector<std::vector<double>>>;
-
 class Grid
 {
 protected:
@@ -29,17 +26,17 @@ private:
     void constructGridParams() override;
     void constructMesh() override;
 
-    const unsigned int m_gridPoints{};
+    const unsigned long m_gridPoints{};
     double m_gridSpacing{};
     double m_fourierGridSpacing{};
     double m_length{};
     Mesh1D m_mesh{};
 
 public:
-    Grid1D(unsigned int nx, double dx);
+    Grid1D(unsigned long nx, double dx);
     ~Grid1D() override = default;
 
-    [[nodiscard]] unsigned int shape() const;
+    [[nodiscard]] unsigned long shape() const;
     [[nodiscard]] double gridSpacing() const;
     [[nodiscard]] double fourierGridSpacing() const;
     [[nodiscard]] double gridLength() const;
@@ -50,11 +47,11 @@ public:
 
 struct Mesh2D
 {
-    vector2D_t xMesh{};
-    vector2D_t yMesh{};
-    vector2D_t xFourierMesh{};
-    vector2D_t yFourierMesh{};
-    vector2D_t wavenumber{};
+    std::vector<double> xMesh{};
+    std::vector<double> yMesh{};
+    std::vector<double> xFourierMesh{};
+    std::vector<double> yFourierMesh{};
+    std::vector<double> wavenumber{};
 };
 
 class Grid2D : public Grid
@@ -63,35 +60,35 @@ private:
     void constructGridParams() override;
     void constructMesh() override;
 
-    const std::tuple<unsigned int, unsigned int> m_gridPoints{};
+    const std::tuple<unsigned long, unsigned long> m_gridPoints{};
     const std::tuple<double, double> m_gridSpacing{};
     std::tuple<double, double> m_fourierGridSpacing{};
     std::tuple<double, double> m_gridLength{};
     Mesh2D m_mesh{};
 
 public:
-    Grid2D(std::tuple<unsigned int, unsigned int> points,
+    Grid2D(std::tuple<unsigned long, unsigned long> points,
            std::tuple<double, double> gridSpacing);
     ~Grid2D() override = default;
 
-    [[nodiscard]] std::tuple<unsigned int, unsigned int> shape() const;
+    [[nodiscard]] std::tuple<unsigned long, unsigned long> shape() const;
     [[nodiscard]] std::tuple<double, double> gridSpacing() const;
     [[nodiscard]] std::tuple<double, double> fourierGridSpacing() const;
     [[nodiscard]] std::tuple<double, double> gridLength() const;
-    [[nodiscard]] vector2D_t wavenumber() const;
+    [[nodiscard]] std::vector<double> wavenumber() const;
 
     friend class Wavefunction;
 };
 
 struct Mesh3D
 {
-    vector3D_t xMesh{};
-    vector3D_t yMesh{};
-    vector3D_t zMesh{};
-    vector3D_t xFourierMesh{};
-    vector3D_t yFourierMesh{};
-    vector3D_t zFourierMesh{};
-    vector3D_t wavenumber{};
+    std::vector<double> xMesh{};
+    std::vector<double> yMesh{};
+    std::vector<double> zMesh{};
+    std::vector<double> xFourierMesh{};
+    std::vector<double> yFourierMesh{};
+    std::vector<double> zFourierMesh{};
+    std::vector<double> wavenumber{};
 };
 
 class Grid3D : public Grid
@@ -100,22 +97,24 @@ private:
     void constructGridParams() override;
     void constructMesh() override;
 
-    const std::tuple<unsigned int, unsigned int, unsigned int> m_gridPoints{};
+    const std::tuple<unsigned long, unsigned long, unsigned long>
+            m_gridPoints{};
     const std::tuple<double, double, double> m_gridSpacing{};
     std::tuple<double, double, double> m_fourierGridSpacing{};
     std::tuple<double, double, double> m_gridLength{};
     Mesh3D m_mesh{};
 
 public:
-    Grid3D(std::tuple<unsigned int, unsigned int, unsigned int> points,
+    Grid3D(std::tuple<unsigned long, unsigned long, unsigned long> points,
            std::tuple<double, double, double> gridSpacing);
     ~Grid3D() override = default;
 
-    [[nodiscard]] std::tuple<unsigned int, unsigned int, unsigned int> shape() const;
+    [[nodiscard]] std::tuple<unsigned long, unsigned long, unsigned long>
+    shape() const;
     [[nodiscard]] std::tuple<double, double, double> gridSpacing() const;
     [[nodiscard]] std::tuple<double, double, double> fourierGridSpacing() const;
     [[nodiscard]] std::tuple<double, double, double> gridLength() const;
-    [[nodiscard]] vector3D_t wavenumber() const;
+    [[nodiscard]] std::vector<double> wavenumber() const;
 
     friend class Wavefunction;
 };

--- a/include/grid.h
+++ b/include/grid.h
@@ -26,17 +26,17 @@ private:
     void constructGridParams() override;
     void constructMesh() override;
 
-    const unsigned long m_gridPoints{};
+    const unsigned int m_gridPoints{};
     double m_gridSpacing{};
     double m_fourierGridSpacing{};
     double m_length{};
     Mesh1D m_mesh{};
 
 public:
-    Grid1D(unsigned long nx, double dx);
+    Grid1D(unsigned int nx, double dx);
     ~Grid1D() override = default;
 
-    [[nodiscard]] unsigned long shape() const;
+    [[nodiscard]] unsigned int shape() const;
     [[nodiscard]] double gridSpacing() const;
     [[nodiscard]] double fourierGridSpacing() const;
     [[nodiscard]] double gridLength() const;
@@ -60,18 +60,18 @@ private:
     void constructGridParams() override;
     void constructMesh() override;
 
-    const std::tuple<unsigned long, unsigned long> m_gridPoints{};
+    const std::tuple<unsigned int, unsigned int> m_gridPoints{};
     const std::tuple<double, double> m_gridSpacing{};
     std::tuple<double, double> m_fourierGridSpacing{};
     std::tuple<double, double> m_gridLength{};
     Mesh2D m_mesh{};
 
 public:
-    Grid2D(std::tuple<unsigned long, unsigned long> points,
+    Grid2D(std::tuple<unsigned int, unsigned int> points,
            std::tuple<double, double> gridSpacing);
     ~Grid2D() override = default;
 
-    [[nodiscard]] std::tuple<unsigned long, unsigned long> shape() const;
+    [[nodiscard]] std::tuple<unsigned int, unsigned int> shape() const;
     [[nodiscard]] std::tuple<double, double> gridSpacing() const;
     [[nodiscard]] std::tuple<double, double> fourierGridSpacing() const;
     [[nodiscard]] std::tuple<double, double> gridLength() const;
@@ -97,7 +97,7 @@ private:
     void constructGridParams() override;
     void constructMesh() override;
 
-    const std::tuple<unsigned long, unsigned long, unsigned long>
+    const std::tuple<unsigned int, unsigned int, unsigned int>
             m_gridPoints{};
     const std::tuple<double, double, double> m_gridSpacing{};
     std::tuple<double, double, double> m_fourierGridSpacing{};
@@ -105,11 +105,11 @@ private:
     Mesh3D m_mesh{};
 
 public:
-    Grid3D(std::tuple<unsigned long, unsigned long, unsigned long> points,
+    Grid3D(std::tuple<unsigned int, unsigned int, unsigned int> points,
            std::tuple<double, double, double> gridSpacing);
     ~Grid3D() override = default;
 
-    [[nodiscard]] std::tuple<unsigned long, unsigned long, unsigned long>
+    [[nodiscard]] std::tuple<unsigned int, unsigned int, unsigned int>
     shape() const;
     [[nodiscard]] std::tuple<double, double, double> gridSpacing() const;
     [[nodiscard]] std::tuple<double, double, double> fourierGridSpacing() const;

--- a/include/wavefunction.h
+++ b/include/wavefunction.h
@@ -1,15 +1,17 @@
 #ifndef BECPP_WAVEFUNCTION_H
 #define BECPP_WAVEFUNCTION_H
 
-#include <cmath>
-#include <complex>
-#include <string>
-#include <iostream>
-#include <random>
-#include <algorithm>
-#include "grid.h"
 #include "constants.h"
 #include "fftw3.h"
+#include "grid.h"
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <iostream>
+#include <random>
+#include <string>
+
+using complexVector_t = std::vector<std::complex<double>>;
 
 struct FFTPlans
 {
@@ -22,26 +24,53 @@ class Wavefunction1D
 private:
     const Grid1D& m_grid;
     FFTPlans m_plans{};
-    std::vector<std::complex<double>> m_component{};
-    std::vector<std::complex<double>> m_fourierComponent{};
+    complexVector_t m_component{};
+    complexVector_t m_fourierComponent{};
     double m_atomNumber{};
 
     void createFFTPlans(const Grid1D& grid);
-    void destroyFFTPlans() const;
+    void destroyFFTPlans();
     void updateAtomNumber();
 
 public:
     explicit Wavefunction1D(const Grid1D& grid);
     ~Wavefunction1D();
 
-    [[nodiscard]] std::vector<std::complex<double>>& component();
-    [[nodiscard]] std::vector<std::complex<double>>& fourierComponent();
+    [[nodiscard]] complexVector_t& component();
+    [[nodiscard]] complexVector_t& fourierComponent();
     [[nodiscard]] std::vector<double> density() const;
     [[nodiscard]] double atomNumber() const;
 
     void fft();
     void ifft();
-    void setComponent(std::vector<std::complex<double>>& component);
+    void setComponent(complexVector_t& component);
 };
 
-#endif //BECPP_WAVEFUNCTION_H
+class Wavefunction2D
+{
+private:
+    const Grid2D& m_grid;
+    FFTPlans m_plans{};
+    complexVector_t m_component{};
+    complexVector_t m_fourierComponent{};
+    double m_atomNumber{};
+
+    void createFFTPlans(const Grid2D& grid);
+    void destroyFFTPlans();
+    void updateAtomNumber();
+
+public:
+    explicit Wavefunction2D(const Grid2D& grid);
+    ~Wavefunction2D();
+
+    [[nodiscard]] complexVector_t& component();
+    [[nodiscard]] complexVector_t& fourierComponent();
+    [[nodiscard]] std::vector<double> density() const;
+    [[nodiscard]] double atomNumber() const;
+
+    void fft();
+    void ifft();
+    void setComponent(complexVector_t& component);
+};
+
+#endif//BECPP_WAVEFUNCTION_H

--- a/include/wavefunction.h
+++ b/include/wavefunction.h
@@ -29,7 +29,7 @@ private:
     double m_atomNumber{};
 
     void createFFTPlans(const Grid1D& grid);
-    void destroyFFTPlans();
+    void destroyFFTPlans() const;
     void updateAtomNumber();
 
 public:
@@ -41,7 +41,7 @@ public:
     [[nodiscard]] std::vector<double> density() const;
     [[nodiscard]] double atomNumber() const;
 
-    void fft();
+    void fft() const;
     void ifft();
     void setComponent(complexVector_t& component);
 };
@@ -56,7 +56,7 @@ private:
     double m_atomNumber{};
 
     void createFFTPlans(const Grid2D& grid);
-    void destroyFFTPlans();
+    void destroyFFTPlans() const;
     void updateAtomNumber();
 
 public:
@@ -68,7 +68,7 @@ public:
     [[nodiscard]] std::vector<double> density() const;
     [[nodiscard]] double atomNumber() const;
 
-    void fft();
+    void fft() const;
     void ifft();
     void setComponent(complexVector_t& component);
 };

--- a/include/wavefunction.h
+++ b/include/wavefunction.h
@@ -73,4 +73,31 @@ public:
     void setComponent(complexVector_t& component);
 };
 
+class Wavefunction3D
+{
+private:
+    const Grid3D& m_grid;
+    FFTPlans m_plans{};
+    complexVector_t m_component{};
+    complexVector_t m_fourierComponent{};
+    double m_atomNumber{};
+
+    void createFFTPlans(const Grid3D& grid);
+    void destroyFFTPlans() const;
+    void updateAtomNumber();
+
+public:
+    explicit Wavefunction3D(const Grid3D& grid);
+    ~Wavefunction3D();
+
+    [[nodiscard]] complexVector_t& component();
+    [[nodiscard]] complexVector_t& fourierComponent();
+    [[nodiscard]] std::vector<double> density() const;
+    [[nodiscard]] double atomNumber() const;
+
+    void fft() const;
+    void ifft();
+    void setComponent(complexVector_t& component);
+};
+
 #endif//BECPP_WAVEFUNCTION_H

--- a/include/wavefunction.h
+++ b/include/wavefunction.h
@@ -28,6 +28,7 @@ private:
 
     void createFFTPlans(const Grid1D& grid);
     void destroyFFTPlans() const;
+    void updateAtomNumber();
 
 public:
     explicit Wavefunction1D(const Grid1D& grid);
@@ -38,9 +39,9 @@ public:
     [[nodiscard]] std::vector<double> density() const;
     [[nodiscard]] double atomNumber() const;
 
-    void fft() const;
-    void ifft() const;
-    void setComponent(std::vector<std::complex<double>> component);
+    void fft();
+    void ifft();
+    void setComponent(std::vector<std::complex<double>>& component);
 };
 
 #endif //BECPP_WAVEFUNCTION_H

--- a/include/wavefunction.h
+++ b/include/wavefunction.h
@@ -1,13 +1,8 @@
-//
-// Created by mattw on 05/01/2022.
-//
-
 #ifndef BECPP_WAVEFUNCTION_H
 #define BECPP_WAVEFUNCTION_H
 
 #include <cmath>
 #include <complex>
-#include <chrono>
 #include <string>
 #include <iostream>
 #include <random>
@@ -16,122 +11,36 @@
 #include "constants.h"
 #include "fftw3.h"
 
-// Define arrays
-using complexVector_t = std::vector<std::complex<double>>;
-using complexArray_t = std::vector<complexVector_t>;
-using doubleArray_t = std::vector<std::vector<double>>;
+struct FFTPlans
+{
+    fftw_plan plan_forward{};
+    fftw_plan plan_backward{};
+};
 
 class Wavefunction1D
 {
 private:
-    void generateInitialState(const std::string &gs_phase);
-    void generateFFTPlans();
+    const Grid1D& m_grid;
+    FFTPlans m_plans{};
+    std::vector<std::complex<double>> m_component{};
+    std::vector<std::complex<double>> m_fourierComponent{};
+    double m_atomNumber{};
 
-    // FFT plans
-    fftw_plan forward_plus{};
-    fftw_plan forward_zero{};
-    fftw_plan forward_minus{};
-    fftw_plan backward_plus{};
-    fftw_plan backward_zero{};
-    fftw_plan backward_minus{};
+    void createFFTPlans(const Grid1D& grid);
+    void destroyFFTPlans() const;
 
 public:
-    // Wavefunction2D components arrays
-    complexVector_t plus{};
-    complexVector_t zero{};
-    complexVector_t minus{};
+    explicit Wavefunction1D(const Grid1D& grid);
+    ~Wavefunction1D();
 
-    // Wavefunction2D k-space arrays
-    complexVector_t plus_k{};
-    complexVector_t zero_k{};
-    complexVector_t minus_k{};
+    [[nodiscard]] std::vector<std::complex<double>>& component();
+    [[nodiscard]] std::vector<std::complex<double>>& fourierComponent();
+    [[nodiscard]] std::vector<double> density() const;
+    [[nodiscard]] double atomNumber() const;
 
-    // Reference to grid object
-    Grid1D &grid;
-
-    // Atom numbers
-    double N_plus{};
-    double N_zero{};
-    double N_minus{};
-    double N{};
-
-    // Constructor
-    Wavefunction1D(Grid1D &grid, const std::string &gs_phase);
-
-    // FFT functions
-    void fft();
-    void ifft();
-    void destroy_fft_plans();
-
-    // Member functions
-    void add_noise(std::string const &components, double mean, double stddev);
-
-    std::vector<double> density();
-
-    double atom_number();
-
-    double component_atom_number(const std::string &component);
-
-    void update_component_atom_num();
-
+    void fft() const;
+    void ifft() const;
+    void setComponent(std::vector<std::complex<double>> component);
 };
-
-class Wavefunction2D
-{
-private:
-    void generateInitialState(const std::string &gs_phase);
-    void generateFFTPlans();
-
-    // FFT plans
-    fftw_plan forward_plus{};
-    fftw_plan forward_zero{};
-    fftw_plan forward_minus{};
-    fftw_plan backward_plus{};
-    fftw_plan backward_zero{};
-    fftw_plan backward_minus{};
-
-public:
-    // Wavefunction2D components arrays
-    complexVector_t plus{};
-    complexVector_t zero{};
-    complexVector_t minus{};
-
-    // Wavefunction2D k-space arrays
-    complexVector_t plus_k{};
-    complexVector_t zero_k{};
-    complexVector_t minus_k{};
-
-    // Reference to grid object
-    Grid2D &grid;
-
-    // Atom numbers
-    double N_plus{};
-    double N_zero{};
-    double N_minus{};
-    double N{};
-
-    // Constructor
-    Wavefunction2D(Grid2D &grid, const std::string &gs_phase);
-
-    // FFT functions
-    void fft();
-    void ifft();
-    void destroy_fft_plans();
-
-    // Member functions
-    void add_noise(std::string const &components, double mean, double stddev);
-
-    void apply_phase(const doubleArray_t &phase_profile);
-
-    doubleArray_t density();
-
-    double atom_number();
-
-    double component_atom_number(const std::string &component);
-
-    void update_component_atom_num();
-
-};
-
 
 #endif //BECPP_WAVEFUNCTION_H

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -4,8 +4,7 @@
 #include <cmath>
 #include <utility>
 
-Grid1D::Grid1D(unsigned long nx, double dx)
-    : m_gridPoints{nx}, m_gridSpacing{dx}
+Grid1D::Grid1D(unsigned int nx, double dx) : m_gridPoints{nx}, m_gridSpacing{dx}
 {
     Grid1D::constructGridParams();
     Grid1D::constructMesh();
@@ -17,7 +16,7 @@ void Grid1D::constructGridParams()
     m_length = m_gridPoints * m_gridSpacing;
 }
 
-void resizeMesh1D(Mesh1D& mesh, unsigned long xPoints)
+void resizeMesh1D(Mesh1D& mesh, unsigned int xPoints)
 {
     mesh.xMesh.resize(xPoints);
     mesh.xFourierMesh.resize(xPoints);
@@ -46,7 +45,7 @@ void Grid1D::constructMesh()
     }
 }
 
-unsigned long Grid1D::shape() const { return m_gridPoints; }
+unsigned int Grid1D::shape() const { return m_gridPoints; }
 
 double Grid1D::gridSpacing() const { return m_gridSpacing; }
 
@@ -56,7 +55,7 @@ double Grid1D::gridLength() const { return m_length; }
 
 std::vector<double> Grid1D::wavenumber() const { return m_mesh.wavenumber; }
 
-Grid2D::Grid2D(std::tuple<unsigned long, unsigned long> points,
+Grid2D::Grid2D(std::tuple<unsigned int, unsigned int> points,
                std::tuple<double, double> gridSpacing)
     : m_gridPoints{std::move(points)}, m_gridSpacing{std::move(gridSpacing)}
 {
@@ -74,7 +73,7 @@ void Grid2D::constructGridParams()
     m_gridLength = {xPoints * xGridSpacing, yPoints * yGridSpacing};
 }
 
-void resizeMesh2D(Mesh2D& mesh, unsigned long xPoints, unsigned long yPoints)
+void resizeMesh2D(Mesh2D& mesh, unsigned int xPoints, unsigned int yPoints)
 {
     mesh.xMesh.resize(xPoints * yPoints);
     mesh.yMesh.resize(xPoints * yPoints);
@@ -94,28 +93,28 @@ void Grid2D::constructMesh()
     {
         for (int j = 0; j < yPoints; ++j)
         {
-            m_mesh.xMesh[j + i * yPoints] = (j - xPoints / 2.) * xGridSpacing;
-            m_mesh.yMesh[j + i * yPoints] = (j - yPoints / 2.) * yGridSpacing;
+            auto index = j + i * yPoints;
+            m_mesh.xMesh[index] = (j - xPoints / 2.) * xGridSpacing;
+            m_mesh.yMesh[index] = (j - yPoints / 2.) * yGridSpacing;
             if (i < xPoints / 2)
             {
-                m_mesh.xFourierMesh[j + i * yPoints] = i * xFourierGridSpacing;
-                m_mesh.yFourierMesh[j + i * yPoints] = j * yFourierGridSpacing;
+                m_mesh.xFourierMesh[index] = i * xFourierGridSpacing;
+                m_mesh.yFourierMesh[index] = j * yFourierGridSpacing;
             } else
             {
-                m_mesh.xFourierMesh[j + i * yPoints] =
+                m_mesh.xFourierMesh[index] =
                         (i - xPoints) * xFourierGridSpacing;
-                m_mesh.yFourierMesh[j + i * yPoints] =
+                m_mesh.yFourierMesh[index] =
                         (j - yPoints) * yFourierGridSpacing;
             }
 
-            m_mesh.wavenumber[j + i * yPoints] =
-                    std::pow(m_mesh.xFourierMesh[j + i * yPoints], 2) +
-                    std::pow(m_mesh.yFourierMesh[j + i * yPoints], 2);
+            m_mesh.wavenumber[index] = std::pow(m_mesh.xFourierMesh[index], 2) +
+                                       std::pow(m_mesh.yFourierMesh[index], 2);
         }
     }
 }
 
-std::tuple<unsigned long, unsigned long> Grid2D::shape() const
+std::tuple<unsigned int, unsigned int> Grid2D::shape() const
 {
     return m_gridPoints;
 }
@@ -131,7 +130,7 @@ std::tuple<double, double> Grid2D::gridLength() const { return m_gridLength; }
 
 std::vector<double> Grid2D::wavenumber() const { return m_mesh.wavenumber; }
 
-Grid3D::Grid3D(std::tuple<unsigned long, unsigned long, unsigned long> points,
+Grid3D::Grid3D(std::tuple<unsigned int, unsigned int, unsigned int> points,
                std::tuple<double, double, double> gridSpacing)
     : m_gridPoints{std::move(points)}, m_gridSpacing{std::move(gridSpacing)}
 {
@@ -151,8 +150,8 @@ void Grid3D::constructGridParams()
                     yPoints * zGridSpacing};
 }
 
-void resizeMesh3D(Mesh3D& mesh, unsigned long xPoints, unsigned long yPoints,
-                  unsigned long zPoints)
+void resizeMesh3D(Mesh3D& mesh, unsigned int xPoints, unsigned int yPoints,
+                  unsigned int zPoints)
 {
     mesh.xMesh.resize(xPoints * yPoints * zPoints);
     mesh.yMesh.resize(xPoints * yPoints * zPoints);
@@ -177,44 +176,36 @@ void Grid3D::constructMesh()
         {
             for (int i = 0; i < xPoints; ++i)
             {
-                m_mesh.xMesh[k + zPoints * (j + yPoints * i)] =
-                        (i - xPoints / 2.) * xGridSpacing;
-                m_mesh.yMesh[k + zPoints * (j + yPoints * i)] =
-                        (j - yPoints / 2.) * yGridSpacing;
-                m_mesh.zMesh[k + zPoints * (j + yPoints * i)] =
-                        (k - zPoints / 2.) * zGridSpacing;
+                auto index = k + zPoints * (j + yPoints * i);
+                m_mesh.xMesh[index] = (i - xPoints / 2.) * xGridSpacing;
+                m_mesh.yMesh[index] = (j - yPoints / 2.) * yGridSpacing;
+                m_mesh.zMesh[index] = (k - zPoints / 2.) * zGridSpacing;
 
                 if (i < xPoints / 2)
                 {
-                    m_mesh.xFourierMesh[k + zPoints * (j + yPoints * i)] =
-                            i * xFourierGridSpacing;
-                    m_mesh.yFourierMesh[k + zPoints * (j + yPoints * i)] =
-                            j * yFourierGridSpacing;
-                    m_mesh.zFourierMesh[k + zPoints * (j + yPoints * i)] =
-                            k * yFourierGridSpacing;
+                    m_mesh.xFourierMesh[index] = i * xFourierGridSpacing;
+                    m_mesh.yFourierMesh[index] = j * yFourierGridSpacing;
+                    m_mesh.zFourierMesh[index] = k * yFourierGridSpacing;
                 } else
                 {
-                    m_mesh.xFourierMesh[k + zPoints * (j + yPoints * i)] =
+                    m_mesh.xFourierMesh[index] =
                             (i - xPoints) * xFourierGridSpacing;
-                    m_mesh.yFourierMesh[k + zPoints * (j + yPoints * i)] =
+                    m_mesh.yFourierMesh[index] =
                             (j - yPoints) * yFourierGridSpacing;
-                    m_mesh.zFourierMesh[k + zPoints * (j + yPoints * i)] =
+                    m_mesh.zFourierMesh[index] =
                             (k - zPoints) * yFourierGridSpacing;
                 }
 
-                m_mesh.wavenumber[k + zPoints * (j + yPoints * i)] =
-                        std::pow(m_mesh.xFourierMesh[k + zPoints * (j + yPoints * i)],
-                                 2) +
-                        std::pow(m_mesh.yFourierMesh[k + zPoints * (j + yPoints * i)],
-                                 2) +
-                        std::pow(m_mesh.zFourierMesh[k + zPoints * (j + yPoints * i)],
-                                 2);
+                m_mesh.wavenumber[index] =
+                        std::pow(m_mesh.xFourierMesh[index], 2) +
+                        std::pow(m_mesh.yFourierMesh[index], 2) +
+                        std::pow(m_mesh.zFourierMesh[index], 2);
             }
         }
     }
 }
 
-std::tuple<unsigned long, unsigned long, unsigned long> Grid3D::shape() const
+std::tuple<unsigned int, unsigned int, unsigned int> Grid3D::shape() const
 {
     return m_gridPoints;
 }

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -177,40 +177,37 @@ void Grid3D::constructMesh()
         {
             for (int i = 0; i < xPoints; ++i)
             {
-                m_mesh.xMesh[k + j * xPoints + i * yPoints] =
+                m_mesh.xMesh[k + zPoints * (j + yPoints * i)] =
                         (i - xPoints / 2.) * xGridSpacing;
-                m_mesh.yMesh[k + j * xPoints + i * yPoints] =
+                m_mesh.yMesh[k + zPoints * (j + yPoints * i)] =
                         (j - yPoints / 2.) * yGridSpacing;
-                m_mesh.zMesh[k + j * xPoints + i * yPoints] =
+                m_mesh.zMesh[k + zPoints * (j + yPoints * i)] =
                         (k - zPoints / 2.) * zGridSpacing;
 
                 if (i < xPoints / 2)
                 {
-                    m_mesh.xFourierMesh[k + j * xPoints + i * yPoints] =
+                    m_mesh.xFourierMesh[k + zPoints * (j + yPoints * i)] =
                             i * xFourierGridSpacing;
-                    m_mesh.yFourierMesh[k + j * xPoints + i * yPoints] =
+                    m_mesh.yFourierMesh[k + zPoints * (j + yPoints * i)] =
                             j * yFourierGridSpacing;
-                    m_mesh.zFourierMesh[k + j * xPoints + i * yPoints] =
+                    m_mesh.zFourierMesh[k + zPoints * (j + yPoints * i)] =
                             k * yFourierGridSpacing;
                 } else
                 {
-                    m_mesh.xFourierMesh[k + j * xPoints + i * yPoints] =
+                    m_mesh.xFourierMesh[k + zPoints * (j + yPoints * i)] =
                             (i - xPoints) * xFourierGridSpacing;
-                    m_mesh.yFourierMesh[k + j * xPoints + i * yPoints] =
+                    m_mesh.yFourierMesh[k + zPoints * (j + yPoints * i)] =
                             (j - yPoints) * yFourierGridSpacing;
-                    m_mesh.zFourierMesh[k + j * xPoints + i * yPoints] =
+                    m_mesh.zFourierMesh[k + zPoints * (j + yPoints * i)] =
                             (k - zPoints) * yFourierGridSpacing;
                 }
 
-                m_mesh.wavenumber[k + j * xPoints + i * yPoints] =
-                        std::pow(m_mesh.xFourierMesh[k + j * xPoints +
-                                                     i * yPoints],
+                m_mesh.wavenumber[k + zPoints * (j + yPoints * i)] =
+                        std::pow(m_mesh.xFourierMesh[k + zPoints * (j + yPoints * i)],
                                  2) +
-                        std::pow(m_mesh.yFourierMesh[k + j * xPoints +
-                                                     i * yPoints],
+                        std::pow(m_mesh.yFourierMesh[k + zPoints * (j + yPoints * i)],
                                  2) +
-                        std::pow(m_mesh.zFourierMesh[k + j * xPoints +
-                                                     i * yPoints],
+                        std::pow(m_mesh.zFourierMesh[k + zPoints * (j + yPoints * i)],
                                  2);
             }
         }

--- a/src/wavefunction.cpp
+++ b/src/wavefunction.cpp
@@ -1,386 +1,70 @@
-//
-// Created by mattw on 05/01/2022.
-//
-
 #include "wavefunction.h"
 
-void Wavefunction2D::generateInitialState(const std::string &gs_phase)
+#include <utility>
+
+Wavefunction1D::Wavefunction1D(const Grid1D& grid) : m_grid{grid}
 {
-    if (gs_phase == "polar")
-    {
-        std::cout << "Generating polar initial state...\n";
-        std::fill(plus.begin(), plus.end(), 0.);
-        std::fill(zero.begin(), zero.end(), 1.);
-        std::fill(minus.begin(), minus.end(), 0.);
-    } else if (gs_phase == "FM")
-    {
-        std::cout << "Generating ferromagnetic initial state...\n";
-        std::fill(plus.begin(), plus.end(), 1 / sqrt(2.));
-        std::fill(zero.begin(), zero.end(), 0.);
-        std::fill(minus.begin(), minus.end(), 1 / sqrt(2.));
-    }
+    m_component.resize(grid.shape());
+    m_fourierComponent.resize(grid.shape());
+
+    createFFTPlans(grid);
 }
 
-Wavefunction2D::Wavefunction2D(Grid2D &grid, const std::string &gs_phase) : grid{grid}
+void Wavefunction1D::createFFTPlans(const Grid1D& grid)
 {
-    // Size arrays
-    plus.resize(grid.m_xPoints * grid.m_yPoints);
-    zero.resize(grid.m_xPoints * grid.m_yPoints);
-    minus.resize(grid.m_xPoints * grid.m_yPoints);
-    plus_k.resize(grid.m_xPoints * grid.m_yPoints);
-    zero_k.resize(grid.m_xPoints * grid.m_yPoints);
-    minus_k.resize(grid.m_xPoints * grid.m_yPoints);
-
-    // Populates wavefunction components
-    generateFFTPlans();
-    generateInitialState(gs_phase);
-
-    update_component_atom_num();
+    m_plans.plan_forward = fftw_plan_dft_1d(
+            static_cast<int>(grid.shape()),
+            reinterpret_cast<fftw_complex*>(&m_component[0]),
+            reinterpret_cast<fftw_complex*>(&m_fourierComponent[0]),
+            FFTW_FORWARD, FFTW_MEASURE);
+    m_plans.plan_backward = fftw_plan_dft_1d(
+            static_cast<int>(grid.shape()),
+            reinterpret_cast<fftw_complex*>(&m_fourierComponent[0]),
+            reinterpret_cast<fftw_complex*>(&m_component[0]), FFTW_BACKWARD,
+            FFTW_MEASURE);
 }
 
-void Wavefunction2D::add_noise(const std::string &components, double mean, double stddev)
+Wavefunction1D::~Wavefunction1D() { destroyFFTPlans(); }
+
+void Wavefunction1D::destroyFFTPlans() const
 {
-    // Construct random generator
-    unsigned seed1 = std::chrono::system_clock::now().time_since_epoch().count();
-    std::default_random_engine generator{seed1};
-    std::normal_distribution<double> norm_dist{mean, stddev};
-
-    if (components == "outer")
-    {
-        std::cout << "Adding noise...\n";
-
-        // Add noise to outer components
-        for (int i = 0; i < grid.m_xPoints; i++)
-        {
-            for (int j = 0; j < grid.m_yPoints; j++)
-            {
-                plus[j + i * grid.m_xPoints] +=
-                        std::complex<double>{norm_dist(generator), norm_dist(generator)};
-                minus[j + i * grid.m_xPoints] +=
-                        std::complex<double>{norm_dist(generator), norm_dist(generator)};
-            }
-        }
-    }
-
-    update_component_atom_num();
+    fftw_destroy_plan(m_plans.plan_forward);
+    fftw_destroy_plan(m_plans.plan_backward);
 }
 
-doubleArray_t Wavefunction2D::density()
+std::vector<std::complex<double>>& Wavefunction1D::component()
 {
-    doubleArray_t density{};
-    density.resize(grid.m_xPoints, std::vector<double>(grid.m_yPoints));
-
-    for (int i = 0; i < grid.m_xPoints; i++)
-    {
-        for (int j = 0; j < grid.m_yPoints; j++)
-        {
-            density[i][j] += (std::pow(std::abs(plus[j + i * grid.m_yPoints]), 2)
-                              + std::pow(std::abs(zero[j + i * grid.m_yPoints]), 2)
-                              + std::pow(std::abs(minus[j + i * grid.m_yPoints]), 2));
-        }
-    }
-    return density;
+    return m_component;
 }
 
-void Wavefunction2D::generateFFTPlans()
+std::vector<std::complex<double>>& Wavefunction1D::fourierComponent()
 {
-
-    forward_plus = fftw_plan_dft_2d(grid.m_xPoints, grid.m_yPoints, reinterpret_cast<fftw_complex *>(&plus[0]),
-                                    reinterpret_cast<fftw_complex *>(&plus_k[0]), FFTW_FORWARD, FFTW_MEASURE);
-    forward_zero = fftw_plan_dft_2d(grid.m_xPoints, grid.m_yPoints, reinterpret_cast<fftw_complex *>(&zero[0]),
-                                    reinterpret_cast<fftw_complex *>(&zero_k[0]), FFTW_FORWARD, FFTW_MEASURE);
-    forward_minus = fftw_plan_dft_2d(grid.m_xPoints, grid.m_yPoints, reinterpret_cast<fftw_complex *>(&minus[0]),
-                                     reinterpret_cast<fftw_complex *>(&minus_k[0]), FFTW_FORWARD, FFTW_MEASURE);
-
-    backward_plus = fftw_plan_dft_2d(grid.m_xPoints, grid.m_yPoints, reinterpret_cast<fftw_complex *>(&plus_k[0]),
-                                     reinterpret_cast<fftw_complex *>(&plus[0]), FFTW_BACKWARD, FFTW_MEASURE);
-    backward_zero = fftw_plan_dft_2d(grid.m_xPoints, grid.m_yPoints, reinterpret_cast<fftw_complex *>(&zero_k[0]),
-                                     reinterpret_cast<fftw_complex *>(&zero[0]), FFTW_BACKWARD, FFTW_MEASURE);
-    backward_minus = fftw_plan_dft_2d(grid.m_xPoints, grid.m_yPoints, reinterpret_cast<fftw_complex *>(&minus_k[0]),
-                                      reinterpret_cast<fftw_complex *>(&minus[0]), FFTW_BACKWARD, FFTW_MEASURE);
+    return m_fourierComponent;
 }
 
-void Wavefunction2D::fft()
-{
-    fftw_execute(forward_plus);
-    fftw_execute(forward_zero);
-    fftw_execute(forward_minus);
-}
-
-void Wavefunction2D::ifft()
-{
-    fftw_execute(backward_plus);
-    fftw_execute(backward_zero);
-    fftw_execute(backward_minus);
-
-    // Scale output
-    double size = grid.m_xPoints * grid.m_yPoints;
-    std::transform(plus.begin(), plus.end(), plus.begin(), [&size](auto &c)
-    { return c / size; });
-    std::transform(zero.begin(), zero.end(), zero.begin(), [&size](auto &c)
-    { return c / size; });
-    std::transform(minus.begin(), minus.end(), minus.begin(), [&size](auto &c)
-    { return c / size; });
-
-}
-
-double Wavefunction2D::atom_number()
-{
-    double atom_num = 0;
-    for (int i = 0; i < grid.m_xPoints; ++i)
-    {
-        for (int j = 0; j < grid.m_yPoints; ++j)
-        {
-            atom_num += grid.m_xGridSpacing * grid.m_yGridSpacing * (std::pow(abs(plus[j + i * grid.m_yPoints]), 2) +
-                                             std::pow(abs(zero[j + i * grid.m_yPoints]), 2) +
-                                             std::pow(abs(minus[j + i * grid.m_yPoints]), 2));
-        }
-    }
-    return atom_num;
-}
-
-void Wavefunction2D::update_component_atom_num()
-{
-    N_plus = 0.;
-    N_zero = 0.;
-    N_minus = 0.;
-
-    for (int i = 0; i < grid.m_xPoints; ++i)
-    {
-        for (int j = 0; j < grid.m_yPoints; ++j)
-        {
-            N_plus += grid.m_xGridSpacing * grid.m_yGridSpacing * std::pow(abs(plus[j + i * grid.m_yPoints]), 2);
-            N_zero += grid.m_xGridSpacing * grid.m_yGridSpacing * std::pow(abs(zero[j + i * grid.m_yPoints]), 2);
-            N_minus += grid.m_xGridSpacing * grid.m_yGridSpacing * std::pow(abs(minus[j + i * grid.m_yPoints]), 2);
-        }
-    }
-
-    N = N_plus + N_zero + N_minus;
-}
-
-double Wavefunction2D::component_atom_number(const std::string &component)
-{
-    double component_atom_num = 0;
-
-    if (component == "plus")
-    {
-        for (int i = 0; i < grid.m_xPoints; ++i)
-        {
-            for (int j = 0; j < grid.m_yPoints; ++j)
-            {
-                component_atom_num += grid.m_xGridSpacing * grid.m_yGridSpacing * std::pow(abs(plus[j + i * grid.m_yPoints]), 2);
-            }
-        }
-
-    } else if (component == "zero")
-    {
-        for (int i = 0; i < grid.m_xPoints; ++i)
-        {
-            for (int j = 0; j < grid.m_yPoints; ++j)
-            {
-                component_atom_num += grid.m_xGridSpacing * grid.m_yGridSpacing * std::pow(abs(zero[j + i * grid.m_yPoints]), 2);
-            }
-        }
-
-    } else if (component == "minus")
-    {
-        for (int i = 0; i < grid.m_xPoints; ++i)
-        {
-            for (int j = 0; j < grid.m_yPoints; ++j)
-            {
-                component_atom_num += grid.m_xGridSpacing * grid.m_yGridSpacing * std::pow(abs(minus[j + i * grid.m_yPoints]), 2);
-            }
-        }
-    }
-    return component_atom_num;
-}
-
-void Wavefunction2D::apply_phase(const doubleArray_t &phase_profile)
-{
-    for (int i = 0; i < grid.m_xPoints; ++i)
-    {
-        for (int j = 0; j < grid.m_yPoints; ++j)
-        {
-            plus[j + i * grid.m_yPoints] *= exp(std::complex<double>{0, 1} * phase_profile[i][j]);
-            zero[j + i * grid.m_yPoints] *= exp(std::complex<double>{0, 1} * phase_profile[i][j]);
-            minus[j + i * grid.m_yPoints] *= exp(std::complex<double>{0, 1} * phase_profile[i][j]);
-        }
-    }
-}
-
-void Wavefunction2D::destroy_fft_plans()
-{
-    fftw_destroy_plan(forward_plus);
-    fftw_destroy_plan(forward_zero);
-    fftw_destroy_plan(forward_minus);
-    fftw_destroy_plan(backward_plus);
-    fftw_destroy_plan(backward_zero);
-    fftw_destroy_plan(backward_minus);
-}
-
-void Wavefunction1D::generateInitialState(const std::string &gs_phase)
-{
-    if (gs_phase == "polar")
-    {
-        std::cout << "Generating polar initial state...\n";
-        std::fill(plus.begin(), plus.end(), 0.);
-        std::fill(zero.begin(), zero.end(), 1.);
-        std::fill(minus.begin(), minus.end(), 0.);
-    } else if (gs_phase == "FM")
-    {
-        std::cout << "Generating ferromagnetic initial state...\n";
-        std::fill(plus.begin(), plus.end(), 1 / sqrt(2.));
-        std::fill(zero.begin(), zero.end(), 0.);
-        std::fill(minus.begin(), minus.end(), 1 / sqrt(2.));
-    }
-}
-
-void Wavefunction1D::generateFFTPlans()
-{
-    forward_plus = fftw_plan_dft_1d(grid.m_xPoints, reinterpret_cast<fftw_complex *>(&plus[0]),
-                                    reinterpret_cast<fftw_complex *>(&plus_k[0]), FFTW_FORWARD, FFTW_MEASURE);
-    forward_zero = fftw_plan_dft_1d(grid.m_xPoints, reinterpret_cast<fftw_complex *>(&zero[0]),
-                                    reinterpret_cast<fftw_complex *>(&zero_k[0]), FFTW_FORWARD, FFTW_MEASURE);
-    forward_minus = fftw_plan_dft_1d(grid.m_xPoints, reinterpret_cast<fftw_complex *>(&minus[0]),
-                                     reinterpret_cast<fftw_complex *>(&minus_k[0]), FFTW_FORWARD, FFTW_MEASURE);
-
-    backward_plus = fftw_plan_dft_1d(grid.m_xPoints, reinterpret_cast<fftw_complex *>(&plus_k[0]),
-                                     reinterpret_cast<fftw_complex *>(&plus[0]), FFTW_BACKWARD, FFTW_MEASURE);
-    backward_zero = fftw_plan_dft_1d(grid.m_xPoints, reinterpret_cast<fftw_complex *>(&zero_k[0]),
-                                     reinterpret_cast<fftw_complex *>(&zero[0]), FFTW_BACKWARD, FFTW_MEASURE);
-    backward_minus = fftw_plan_dft_1d(grid.m_xPoints, reinterpret_cast<fftw_complex *>(&minus_k[0]),
-                                      reinterpret_cast<fftw_complex *>(&minus[0]), FFTW_BACKWARD, FFTW_MEASURE);
-}
-
-Wavefunction1D::Wavefunction1D(Grid1D &grid, const std::string &gs_phase) : grid{grid}
-{
-    // Size arrays
-    plus.resize(grid.m_xPoints);
-    zero.resize(grid.m_xPoints);
-    minus.resize(grid.m_xPoints);
-    plus_k.resize(grid.m_xPoints);
-    zero_k.resize(grid.m_xPoints);
-    minus_k.resize(grid.m_xPoints);
-
-    // Populates wavefunction components
-    generateFFTPlans();
-    generateInitialState(gs_phase);
-
-    update_component_atom_num();
-}
-
-void Wavefunction1D::fft()
-{
-    fftw_execute(forward_plus);
-    fftw_execute(forward_zero);
-    fftw_execute(forward_minus);
-}
-
-void Wavefunction1D::ifft()
-{
-    fftw_execute(backward_plus);
-    fftw_execute(backward_zero);
-    fftw_execute(backward_minus);
-}
-
-void Wavefunction1D::destroy_fft_plans()
-{
-    fftw_destroy_plan(forward_plus);
-    fftw_destroy_plan(forward_zero);
-    fftw_destroy_plan(forward_minus);
-    fftw_destroy_plan(backward_plus);
-    fftw_destroy_plan(backward_zero);
-    fftw_destroy_plan(backward_minus);
-}
-
-void Wavefunction1D::add_noise(const std::string &components, double mean, double stddev)
-{
-    // Construct random generator
-    unsigned seed1 = std::chrono::system_clock::now().time_since_epoch().count();
-    std::default_random_engine generator{seed1};
-    std::normal_distribution<double> norm_dist{mean, stddev};
-
-    if (components == "outer")
-    {
-        std::cout << "Adding noise...\n";
-
-        // Add noise to outer components
-        for (int i = 0; i < grid.m_xPoints; i++)
-        {
-            plus[i] += std::complex<double>{norm_dist(generator), norm_dist(generator)};
-            minus[i] += std::complex<double>{norm_dist(generator), norm_dist(generator)};
-        }
-    }
-
-    update_component_atom_num();
-}
-
-std::vector<double> Wavefunction1D::density()
+std::vector<double> Wavefunction1D::density() const
 {
     std::vector<double> density{};
-    density.resize(grid.m_xPoints);
-
-    for (int i = 0; i < grid.m_xPoints; i++)
+    density.resize(m_grid.shape());
+    for (int i = 0; i < m_grid.shape(); ++i)
     {
-        density[i] += (std::pow(std::abs(plus[i]), 2)
-                       + std::pow(std::abs(zero[i]), 2)
-                       + std::pow(std::abs(minus[i]), 2));
+        density[i] = std::pow(std::abs(m_component[i]), 2);
     }
+
     return density;
 }
 
-double Wavefunction1D::atom_number()
-{
-    double atom_num = 0;
-    for (int i = 0; i < grid.m_xPoints; ++i)
-    {
-        atom_num += grid.m_xGridSpacing * (std::pow(abs(plus[i]), 2)
-                               + std::pow(abs(zero[i]), 2)
-                               + std::pow(abs(minus[i]), 2));
-    }
-    return atom_num;
+double Wavefunction1D::atomNumber() const { return m_atomNumber; }
+
+void Wavefunction1D::fft() const {
+    fftw_execute(m_plans.plan_forward);
 }
 
-double Wavefunction1D::component_atom_number(const std::string &component)
-{
-    double component_atom_num = 0;
-
-    if (component == "plus")
-    {
-        for (int i = 0; i < grid.m_xPoints; ++i)
-        {
-            component_atom_num += grid.m_xGridSpacing *  std::pow(abs(plus[i]), 2);
-        }
-
-    } else if (component == "zero")
-    {
-        for (int i = 0; i < grid.m_xPoints; ++i)
-        {
-            component_atom_num += grid.m_xGridSpacing * std::pow(abs(zero[i]), 2);
-        }
-
-    } else if (component == "minus")
-    {
-        for (int i = 0; i < grid.m_xPoints; ++i)
-        {
-            component_atom_num += grid.m_xGridSpacing * std::pow(abs(minus[i]), 2);
-        }
-    }
-    return component_atom_num;
+void Wavefunction1D::ifft() const {
+    fftw_execute(m_plans.plan_backward);
 }
 
-void Wavefunction1D::update_component_atom_num()
+void Wavefunction1D::setComponent(std::vector<std::complex<double>> component)
 {
-    N_plus = 0.;
-    N_zero = 0.;
-    N_minus = 0.;
-
-    for (int i = 0; i < grid.m_xPoints; ++i)
-    {
-        N_plus += grid.m_xGridSpacing * std::pow(abs(plus[i]), 2);
-        N_zero += grid.m_xGridSpacing * std::pow(abs(zero[i]), 2);
-        N_minus += grid.m_xGridSpacing * std::pow(abs(minus[i]), 2);
-    }
-
-    N = N_plus + N_zero + N_minus;
+    m_component = std::move(component);
 }

--- a/src/wavefunction.cpp
+++ b/src/wavefunction.cpp
@@ -1,7 +1,5 @@
 #include "wavefunction.h"
 
-#include <utility>
-
 Wavefunction1D::Wavefunction1D(const Grid1D& grid) : m_grid{grid}
 {
     m_component.resize(grid.shape());
@@ -26,16 +24,13 @@ void Wavefunction1D::createFFTPlans(const Grid1D& grid)
 
 Wavefunction1D::~Wavefunction1D() { destroyFFTPlans(); }
 
-void Wavefunction1D::destroyFFTPlans()
+void Wavefunction1D::destroyFFTPlans() const
 {
     fftw_destroy_plan(m_plans.plan_forward);
     fftw_destroy_plan(m_plans.plan_backward);
 }
 
-complexVector_t& Wavefunction1D::component()
-{
-    return m_component;
-}
+complexVector_t& Wavefunction1D::component() { return m_component; }
 
 complexVector_t& Wavefunction1D::fourierComponent()
 {
@@ -56,7 +51,7 @@ std::vector<double> Wavefunction1D::density() const
 
 double Wavefunction1D::atomNumber() const { return m_atomNumber; }
 
-void Wavefunction1D::fft() { fftw_execute(m_plans.plan_forward); }
+void Wavefunction1D::fft() const { fftw_execute(m_plans.plan_forward); }
 
 void Wavefunction1D::ifft()
 {
@@ -65,7 +60,7 @@ void Wavefunction1D::ifft()
     // Renormalise wavefunction
     for (size_t i = 0; i < m_grid.shape(); i++)
     {
-        m_component[i] /= m_grid.shape();
+        m_component[i] /= static_cast<double>(m_grid.shape());
     }
 }
 
@@ -113,16 +108,13 @@ void Wavefunction2D::createFFTPlans(const Grid2D& grid)
 
 Wavefunction2D::~Wavefunction2D() { destroyFFTPlans(); }
 
-void Wavefunction2D::destroyFFTPlans()
+void Wavefunction2D::destroyFFTPlans() const
 {
     fftw_destroy_plan(m_plans.plan_forward);
     fftw_destroy_plan(m_plans.plan_backward);
 }
 
-complexVector_t& Wavefunction2D::component()
-{
-    return m_component;
-}
+complexVector_t& Wavefunction2D::component() { return m_component; }
 
 complexVector_t& Wavefunction2D::fourierComponent()
 {
@@ -148,7 +140,7 @@ std::vector<double> Wavefunction2D::density() const
 
 double Wavefunction2D::atomNumber() const { return m_atomNumber; }
 
-void Wavefunction2D::fft() { fftw_execute(m_plans.plan_forward); }
+void Wavefunction2D::fft() const { fftw_execute(m_plans.plan_forward); }
 
 void Wavefunction2D::ifft()
 {
@@ -160,7 +152,8 @@ void Wavefunction2D::ifft()
     {
         for (size_t j = 0; j < yPoints; j++)
         {
-            m_component[j + i * yPoints] /= xPoints * yPoints;
+            m_component[j + i * yPoints] /=
+                    static_cast<double>(xPoints * yPoints);
         }
     }
 }

--- a/src/wavefunction.cpp
+++ b/src/wavefunction.cpp
@@ -26,18 +26,18 @@ void Wavefunction1D::createFFTPlans(const Grid1D& grid)
 
 Wavefunction1D::~Wavefunction1D() { destroyFFTPlans(); }
 
-void Wavefunction1D::destroyFFTPlans() const
+void Wavefunction1D::destroyFFTPlans()
 {
     fftw_destroy_plan(m_plans.plan_forward);
     fftw_destroy_plan(m_plans.plan_backward);
 }
 
-std::vector<std::complex<double>>& Wavefunction1D::component()
+complexVector_t& Wavefunction1D::component()
 {
     return m_component;
 }
 
-std::vector<std::complex<double>>& Wavefunction1D::fourierComponent()
+complexVector_t& Wavefunction1D::fourierComponent()
 {
     return m_fourierComponent;
 }
@@ -78,7 +78,108 @@ void Wavefunction1D::updateAtomNumber()
     }
 }
 
-void Wavefunction1D::setComponent(std::vector<std::complex<double>>& component)
+void Wavefunction1D::setComponent(complexVector_t& component)
+{
+    m_component = component;
+
+    // Update the Fourier-space wavefunction and atom number
+    fft();
+    updateAtomNumber();
+}
+
+Wavefunction2D::Wavefunction2D(const Grid2D& grid) : m_grid{grid}
+{
+    auto [xPoints, yPoints] = grid.shape();
+    m_component.resize(xPoints * yPoints);
+    m_fourierComponent.resize(xPoints * yPoints);
+
+    createFFTPlans(grid);
+}
+
+void Wavefunction2D::createFFTPlans(const Grid2D& grid)
+{
+    auto [xPoints, yPoints] = grid.shape();
+    m_plans.plan_forward = fftw_plan_dft_2d(
+            static_cast<int>(xPoints), static_cast<int>(yPoints),
+            reinterpret_cast<fftw_complex*>(&m_component[0]),
+            reinterpret_cast<fftw_complex*>(&m_fourierComponent[0]),
+            FFTW_FORWARD, FFTW_MEASURE);
+    m_plans.plan_backward = fftw_plan_dft_2d(
+            static_cast<int>(xPoints), static_cast<int>(yPoints),
+            reinterpret_cast<fftw_complex*>(&m_fourierComponent[0]),
+            reinterpret_cast<fftw_complex*>(&m_component[0]), FFTW_BACKWARD,
+            FFTW_MEASURE);
+}
+
+Wavefunction2D::~Wavefunction2D() { destroyFFTPlans(); }
+
+void Wavefunction2D::destroyFFTPlans()
+{
+    fftw_destroy_plan(m_plans.plan_forward);
+    fftw_destroy_plan(m_plans.plan_backward);
+}
+
+complexVector_t& Wavefunction2D::component()
+{
+    return m_component;
+}
+
+complexVector_t& Wavefunction2D::fourierComponent()
+{
+    return m_fourierComponent;
+}
+
+std::vector<double> Wavefunction2D::density() const
+{
+    std::vector<double> density{};
+    auto [xPoints, yPoints] = m_grid.shape();
+    density.resize(xPoints * yPoints);
+    for (size_t i = 0; i < xPoints; i++)
+    {
+        for (size_t j = 0; j < yPoints; j++)
+        {
+            density[j + i * yPoints] =
+                    std::pow(std::abs(m_component[j + i * yPoints]), 2);
+        }
+    }
+
+    return density;
+}
+
+double Wavefunction2D::atomNumber() const { return m_atomNumber; }
+
+void Wavefunction2D::fft() { fftw_execute(m_plans.plan_forward); }
+
+void Wavefunction2D::ifft()
+{
+    fftw_execute(m_plans.plan_backward);
+
+    // Renormalise wavefunction
+    auto [xPoints, yPoints] = m_grid.shape();
+    for (size_t i = 0; i < xPoints; i++)
+    {
+        for (size_t j = 0; j < yPoints; j++)
+        {
+            m_component[j + i * yPoints] /= xPoints * yPoints;
+        }
+    }
+}
+
+void Wavefunction2D::updateAtomNumber()
+{
+    auto [xPoints, yPoints] = m_grid.shape();
+    auto [xGridSpacing, yGridSpacing] = m_grid.gridSpacing();
+    for (size_t i = 0; i < xPoints; i++)
+    {
+        for (size_t j = 0; j < yPoints; j++)
+        {
+            m_atomNumber += std::pow(std::abs(density()[j + i * yPoints]), 2) *
+                            xGridSpacing * yGridSpacing;
+        }
+    }
+}
+
+void Wavefunction2D::setComponent(complexVector_t& component)
 {
     m_component = component;
 

--- a/src/wavefunction.cpp
+++ b/src/wavefunction.cpp
@@ -58,7 +58,7 @@ void Wavefunction1D::ifft()
     fftw_execute(m_plans.plan_backward);
 
     // Renormalise wavefunction
-    for (size_t i = 0; i < m_grid.shape(); i++)
+    for (int i = 0; i < m_grid.shape(); ++i)
     {
         m_component[i] /= static_cast<double>(m_grid.shape());
     }
@@ -66,7 +66,7 @@ void Wavefunction1D::ifft()
 
 void Wavefunction1D::updateAtomNumber()
 {
-    for (size_t i = 0; i < m_grid.shape(); i++)
+    for (int i = 0; i < m_grid.shape(); ++i)
     {
         m_atomNumber +=
                 std::pow(std::abs(density()[i]), 2) * m_grid.gridSpacing();
@@ -126,9 +126,9 @@ std::vector<double> Wavefunction2D::density() const
     std::vector<double> density{};
     auto [xPoints, yPoints] = m_grid.shape();
     density.resize(xPoints * yPoints);
-    for (size_t i = 0; i < xPoints; i++)
+    for (int i = 0; i < xPoints; ++i)
     {
-        for (size_t j = 0; j < yPoints; j++)
+        for (int j = 0; j < yPoints; ++j)
         {
             density[j + i * yPoints] =
                     std::pow(std::abs(m_component[j + i * yPoints]), 2);
@@ -148,9 +148,9 @@ void Wavefunction2D::ifft()
 
     // Renormalise wavefunction
     auto [xPoints, yPoints] = m_grid.shape();
-    for (size_t i = 0; i < xPoints; i++)
+    for (int i = 0; i < xPoints; ++i)
     {
-        for (size_t j = 0; j < yPoints; j++)
+        for (int j = 0; j < yPoints; ++j)
         {
             m_component[j + i * yPoints] /=
                     static_cast<double>(xPoints * yPoints);
@@ -162,9 +162,9 @@ void Wavefunction2D::updateAtomNumber()
 {
     auto [xPoints, yPoints] = m_grid.shape();
     auto [xGridSpacing, yGridSpacing] = m_grid.gridSpacing();
-    for (size_t i = 0; i < xPoints; i++)
+    for (int i = 0; i < xPoints; ++i)
     {
-        for (size_t j = 0; j < yPoints; j++)
+        for (int j = 0; j < yPoints; ++j)
         {
             m_atomNumber += std::pow(std::abs(density()[j + i * yPoints]), 2) *
                             xGridSpacing * yGridSpacing;
@@ -173,6 +173,118 @@ void Wavefunction2D::updateAtomNumber()
 }
 
 void Wavefunction2D::setComponent(complexVector_t& component)
+{
+    m_component = component;
+
+    // Update the Fourier-space wavefunction and atom number
+    fft();
+    updateAtomNumber();
+}
+
+Wavefunction3D::Wavefunction3D(const Grid3D& grid) : m_grid{grid}
+{
+    auto [xPoints, yPoints, zPoints] = grid.shape();
+    m_component.resize(xPoints * yPoints * zPoints);
+    m_fourierComponent.resize(xPoints * yPoints * zPoints);
+
+    createFFTPlans(grid);
+}
+
+void Wavefunction3D::createFFTPlans(const Grid3D& grid)
+{
+    auto [xPoints, yPoints, zPoints] = grid.shape();
+    m_plans.plan_forward = fftw_plan_dft_3d(
+            static_cast<int>(xPoints), static_cast<int>(yPoints),
+            static_cast<int>(zPoints),
+            reinterpret_cast<fftw_complex*>(&m_component[0]),
+            reinterpret_cast<fftw_complex*>(&m_fourierComponent[0]),
+            FFTW_FORWARD, FFTW_MEASURE);
+    m_plans.plan_backward = fftw_plan_dft_3d(
+            static_cast<int>(xPoints), static_cast<int>(yPoints),
+            static_cast<int>(zPoints),
+            reinterpret_cast<fftw_complex*>(&m_fourierComponent[0]),
+            reinterpret_cast<fftw_complex*>(&m_component[0]), FFTW_BACKWARD,
+            FFTW_MEASURE);
+}
+
+Wavefunction3D::~Wavefunction3D() { destroyFFTPlans(); }
+
+void Wavefunction3D::destroyFFTPlans() const
+{
+    fftw_destroy_plan(m_plans.plan_forward);
+    fftw_destroy_plan(m_plans.plan_backward);
+}
+
+complexVector_t& Wavefunction3D::component() { return m_component; }
+
+complexVector_t& Wavefunction3D::fourierComponent()
+{
+    return m_fourierComponent;
+}
+
+std::vector<double> Wavefunction3D::density() const
+{
+    std::vector<double> density{};
+    auto [xPoints, yPoints, zPoints] = m_grid.shape();
+    density.resize(xPoints * yPoints * zPoints);
+    for (int i = 0; i < xPoints; ++i)
+    {
+        for (int j = 0; j < yPoints; ++j)
+        {
+            for (int k = 0; k < zPoints; ++k)
+            {
+                auto index = k + zPoints * (j + yPoints * i);
+                density[index] = std::pow(std::abs(m_component[index]), 2);
+            }
+        }
+    }
+
+    return density;
+}
+
+double Wavefunction3D::atomNumber() const { return m_atomNumber; }
+
+void Wavefunction3D::fft() const { fftw_execute(m_plans.plan_forward); }
+
+void Wavefunction3D::ifft()
+{
+    fftw_execute(m_plans.plan_backward);
+
+    // Renormalise wavefunction
+    auto [xPoints, yPoints, zPoints] = m_grid.shape();
+    auto n = static_cast<double>(xPoints * yPoints * zPoints);
+    for (int i = 0; i < xPoints; ++i)
+    {
+        for (int j = 0; j < yPoints; ++j)
+        {
+            for (int k = 0; k < zPoints; ++k)
+            {
+                auto index = k + zPoints * (j + yPoints * i);
+                m_component[index] /= n;
+            }
+        }
+    }
+}
+
+void Wavefunction3D::updateAtomNumber()
+{
+    auto [xPoints, yPoints, zPoints] = m_grid.shape();
+    auto [xGridSpacing, yGridSpacing, zGridSpacing] = m_grid.gridSpacing();
+    for (int i = 0; i < xPoints; ++i)
+    {
+        for (int j = 0; j < yPoints; ++j)
+        {
+            for (int k = 0; k < zPoints; ++k)
+            {
+                auto index = k + zPoints * (j + yPoints * i);
+                m_atomNumber += std::pow(std::abs(density()[index]), 2) *
+                                xGridSpacing * yGridSpacing * zGridSpacing;
+            }
+        }
+    }
+}
+
+void Wavefunction3D::setComponent(complexVector_t& component)
 {
     m_component = component;
 

--- a/src/wavefunction.cpp
+++ b/src/wavefunction.cpp
@@ -56,15 +56,33 @@ std::vector<double> Wavefunction1D::density() const
 
 double Wavefunction1D::atomNumber() const { return m_atomNumber; }
 
-void Wavefunction1D::fft() const {
-    fftw_execute(m_plans.plan_forward);
-}
+void Wavefunction1D::fft() { fftw_execute(m_plans.plan_forward); }
 
-void Wavefunction1D::ifft() const {
-    fftw_execute(m_plans.plan_backward);
-}
-
-void Wavefunction1D::setComponent(std::vector<std::complex<double>> component)
+void Wavefunction1D::ifft()
 {
-    m_component = std::move(component);
+    fftw_execute(m_plans.plan_backward);
+
+    // Renormalise wavefunction
+    for (size_t i = 0; i < m_grid.shape(); i++)
+    {
+        m_component[i] /= m_grid.shape();
+    }
+}
+
+void Wavefunction1D::updateAtomNumber()
+{
+    for (size_t i = 0; i < m_grid.shape(); i++)
+    {
+        m_atomNumber +=
+                std::pow(std::abs(density()[i]), 2) * m_grid.gridSpacing();
+    }
+}
+
+void Wavefunction1D::setComponent(std::vector<std::complex<double>>& component)
+{
+    m_component = component;
+
+    // Update the Fourier-space wavefunction and atom number
+    fft();
+    updateAtomNumber();
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,9 +10,8 @@ FETCHCONTENT_DECLARE(
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
-set(SOURCE_FILES test_grid.cpp)
 
-enable_testing()
+set(SOURCE_FILES test_grid.cpp test_wavefunction.cpp)
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
 add_executable(tests

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -63,7 +63,7 @@ TEST_F(Grid2DTest, LengthSetCorrectly)
 
 TEST_F(Grid2DTest, WavenumberSetCorrectly)
 {
-    ASSERT_EQ(grid.wavenumber()[0][0], 0.0);
+    ASSERT_EQ(grid.wavenumber()[0], 0.0);
 }
 
 class Grid3DTest : public ::testing::Test
@@ -109,5 +109,5 @@ TEST_F(Grid3DTest, LengthSetCorrectly)
 
 TEST_F(Grid3DTest, WavenumberSetCorrectly)
 {
-    ASSERT_EQ(grid.wavenumber()[0][0][0], 0.0);
+    ASSERT_EQ(grid.wavenumber()[0], 0.0);
 }

--- a/test/test_wavefunction.cpp
+++ b/test/test_wavefunction.cpp
@@ -1,0 +1,74 @@
+#include "wavefunction.h"
+#include <gtest/gtest.h>
+
+constexpr auto GRID_LENGTH = 128;
+constexpr auto GRID_SPACING = 0.5;
+
+class Wavefunction1DTest : public ::testing::Test
+{
+public:
+    Grid1D grid{GRID_LENGTH, GRID_SPACING};
+    Wavefunction1D wavefunction{grid};
+};
+
+TEST_F(Wavefunction1DTest, SetComponentCorrect)
+{
+    std::vector<std::complex<double>> initialState{};
+    std::complex<double> real{1.0, 0.0};
+    initialState.resize(GRID_LENGTH, real);
+
+    wavefunction.setComponent(initialState);
+    for (int i = 0; i < GRID_LENGTH; ++i)
+    {
+        ASSERT_EQ(wavefunction.component()[i], real);
+    }
+}
+
+TEST_F(Wavefunction1DTest, AtomNumberCorrect)
+{
+    std::vector<std::complex<double>> initialState{};
+    initialState.resize(GRID_LENGTH, {1.0, 0.0});
+    wavefunction.setComponent(initialState);
+
+    ASSERT_EQ(GRID_LENGTH * GRID_SPACING, wavefunction.atomNumber());
+}
+
+TEST_F(Wavefunction1DTest, DensityCorrect)
+{
+    std::vector<std::complex<double>> initialState{};
+    initialState.resize(GRID_LENGTH, {1.0, 0.0});
+    wavefunction.setComponent(initialState);
+
+    for (size_t i = 0; i < GRID_LENGTH; i++)
+    {
+        ASSERT_EQ(wavefunction.density()[i], 1.0);
+    }
+}
+
+TEST_F(Wavefunction1DTest, SameWavefunctionAfterFFT)
+{
+    std::vector<std::complex<double>> initialState{};
+    initialState.resize(GRID_LENGTH, {1.0, 0.0});
+    wavefunction.setComponent(initialState);
+
+    wavefunction.fft();
+    wavefunction.ifft();
+
+    for (int i = 0; i < GRID_LENGTH; ++i)
+    {
+        ASSERT_EQ(initialState[i], wavefunction.component()[i]);
+    }
+}
+
+TEST_F(Wavefunction1DTest, FourierSpaceWavefunctionUpdated)
+{
+    std::vector<std::complex<double>> initialState{};
+    initialState.resize(GRID_LENGTH, {1.0, 2.0});
+    wavefunction.setComponent(initialState);
+
+    std::complex<double> zero{0.0, 0.0};
+
+    // Sufficient to check one element non-zero
+    wavefunction.fft();
+    ASSERT_NE(zero, wavefunction.fourierComponent()[0]);
+}

--- a/test/test_wavefunction.cpp
+++ b/test/test_wavefunction.cpp
@@ -1,7 +1,7 @@
 #include "wavefunction.h"
 #include <gtest/gtest.h>
 
-constexpr auto GRID_LENGTH = 128;
+constexpr auto GRID_LENGTH = 64L;
 constexpr auto GRID_SPACING = 0.5;
 
 class Wavefunction1DTest : public ::testing::Test
@@ -64,6 +64,88 @@ TEST_F(Wavefunction1DTest, FourierSpaceWavefunctionUpdated)
 {
     std::vector<std::complex<double>> initialState{};
     initialState.resize(GRID_LENGTH, {1.0, 2.0});
+    wavefunction.setComponent(initialState);
+
+    std::complex<double> zero{0.0, 0.0};
+
+    // Sufficient to check one element non-zero
+    wavefunction.fft();
+    ASSERT_NE(zero, wavefunction.fourierComponent()[0]);
+}
+
+class Wavefunction2DTest : public ::testing::Test
+{
+public:
+    std::tuple<unsigned long, unsigned long> points{GRID_LENGTH, GRID_LENGTH};
+    std::tuple<double, double> spacing{GRID_SPACING, GRID_SPACING};
+    Grid2D grid{points, spacing};
+    Wavefunction2D wavefunction{grid};
+};
+
+TEST_F(Wavefunction2DTest, SetComponentCorrect)
+{
+    std::vector<std::complex<double>> initialState{};
+    std::complex<double> real{1.0, 0.0};
+    initialState.resize(GRID_LENGTH * GRID_LENGTH, real);
+
+    wavefunction.setComponent(initialState);
+    for (int i = 0; i < GRID_LENGTH; ++i)
+    {
+        for (size_t j = 0; j < GRID_LENGTH; j++)
+        {
+            ASSERT_EQ(wavefunction.component()[j + i * GRID_LENGTH], real);
+        }
+    }
+}
+
+TEST_F(Wavefunction2DTest, AtomNumberCorrect)
+{
+    std::vector<std::complex<double>> initialState{};
+    initialState.resize(GRID_LENGTH * GRID_LENGTH, {1.0, 0.0});
+    wavefunction.setComponent(initialState);
+
+    double atomNumber = GRID_LENGTH * GRID_LENGTH * GRID_SPACING * GRID_SPACING;
+    ASSERT_EQ(atomNumber, wavefunction.atomNumber());
+}
+
+TEST_F(Wavefunction2DTest, DensityCorrect)
+{
+    complexVector_t initialState{};
+    initialState.resize(GRID_LENGTH * GRID_LENGTH, {1.0, 0.0});
+    wavefunction.setComponent(initialState);
+
+    for (int i = 0; i < GRID_LENGTH; ++i)
+    {
+        for (size_t j = 0; j < GRID_LENGTH; j++)
+        {
+            ASSERT_EQ(wavefunction.density()[j + i * GRID_LENGTH], 1.0);
+        }
+    }
+}
+
+TEST_F(Wavefunction2DTest, SameWavefunctionAfterFFT)
+{
+    std::vector<std::complex<double>> initialState{};
+    initialState.resize(GRID_LENGTH * GRID_LENGTH, {1.0, 0.0});
+    wavefunction.setComponent(initialState);
+
+    wavefunction.fft();
+    wavefunction.ifft();
+
+    for (int i = 0; i < GRID_LENGTH; ++i)
+    {
+        for (size_t j = 0; j < GRID_LENGTH; j++)
+        {
+            ASSERT_EQ(initialState[j + i * GRID_LENGTH],
+                      wavefunction.component()[j + i * GRID_LENGTH]);
+        }
+    }
+}
+
+TEST_F(Wavefunction2DTest, FourierSpaceWavefunctionUpdated)
+{
+    std::vector<std::complex<double>> initialState{};
+    initialState.resize(GRID_LENGTH * GRID_LENGTH, {1.0, 2.0});
     wavefunction.setComponent(initialState);
 
     std::complex<double> zero{0.0, 0.0};


### PR DESCRIPTION
This PR brings a redesign to the `Wavefunction` classes! Overall, the new classes are much cleaner and share a unified interface.

## 2D and 3D changes
Due to issues with FFTW, all 2D and 3D arrays have to now be defined as 1D vectors and indexed as though they are 2D/3D versions, e.g.:
https://github.com/wheelerMT/BECpp/blob/7c7f2538b6fe3243f6b08536a141c6fc47c6c6be/src/grid.cpp#L179-L182
Whilst strange syntax, it offers the added benefit of increased performance due to the new 1D vectors being contiguous in memory 😃.